### PR TITLE
feat: review 조회/수정/삭제 임시 구현

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/bookmark/dto/GetBookmark.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/bookmark/dto/GetBookmark.java
@@ -35,13 +35,13 @@ public class GetBookmark {
 
     @Builder
     @QueryProjection
-    public GetBookmark(Bookmark bookmark, String name, Lesson lesson) {
+    public GetBookmark(Bookmark bookmark, Lesson lesson) {
         this.bookmarkId = bookmark.getId();
         this.lessonId = lesson.getId();
-        this.image = "";
+        this.image = lesson.getProfileImage().getFilePath();
         this.bookmarkUrl = bookmark.getBookmarkUrl();
         this.title = lesson.getTitle();
-        this.name = name;
+        this.name = lesson.getName();
         this.cost = lesson.getCost();
         this.languages = lesson.getLessonLanguages().stream()
                 .map(language -> language.getLanguages().getLanguages())

--- a/server/src/main/java/com/codueon/boostUp/domain/bookmark/repository/BookmarkRepositoryImpl.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/bookmark/repository/BookmarkRepositoryImpl.java
@@ -26,8 +26,8 @@ public class BookmarkRepositoryImpl implements CustomBookmarkRepository {
     @Override
     public Page<GetBookmark> getBookmarkList(Long memberId, Pageable pageable) {
         List<GetBookmark> result = queryFactory
-                .select(new QGetBookmark(bookmark,
-                        member.name,
+                .select(new QGetBookmark(
+                        bookmark,
                         lesson
                 ))
                 .from(bookmark)

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonDbService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonDbService.java
@@ -14,7 +14,7 @@ public class LessonDbService {
 
     public Lesson ifExistsReturnLesson(Long lessonId) {
         return lessonRepository.findById(lessonId)
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.PLACE_NOT_FOUND));
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.LESSON_NOT_FOUND));
     }
 
     public void saveLesson(Lesson lesson) {

--- a/server/src/main/java/com/codueon/boostUp/domain/member/service/MemberDbService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/member/service/MemberDbService.java
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberDbService {
     private final MemberRepository memberRepository;
-//    private final PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 사용자 정보 조회 메서드
@@ -71,9 +71,9 @@ public class MemberDbService {
      * @return String(인코딩된 비밀번호)
      * @author LimJaeminZ
      */
-//    public String encodingPassword(String password) {
-//        return passwordEncoder.encode(password);
-//    }
+    public String encodingPassword(String password) {
+        return passwordEncoder.encode(password);
+    }
 
     /**
      * 비밀번호 확인 메서드
@@ -83,8 +83,8 @@ public class MemberDbService {
      * @author LimJaeminZ
      */
     public void isValidPassword(Member findMember, String password) {
-//        if(!passwordEncoder.matches(password, findMember.getPassword())) {
-//            throw new AuthException(ExceptionCode.INVALID_MEMBER);
-//        }
+        if(!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw new AuthException(ExceptionCode.INVALID_MEMBER);
+        }
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/controller/reviewController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/controller/reviewController.java
@@ -3,6 +3,7 @@ package com.codueon.boostUp.domain.reveiw.controller;
 
 import com.codueon.boostUp.domain.dto.MultiResponseDto;
 import com.codueon.boostUp.domain.reveiw.dto.GetReview;
+import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
 import com.codueon.boostUp.domain.reveiw.dto.PatchReview;
 import com.codueon.boostUp.domain.reveiw.dto.PostReview;
 import com.codueon.boostUp.domain.reveiw.service.ReviewService;
@@ -16,13 +17,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/review")
 @RequiredArgsConstructor
+@RequestMapping("/review")
 public class reviewController {
-    private ReviewService reviewService;
+    private final ReviewService reviewService;
 
     /**
-     * 학생 리뷰 생성 컨트롤러 메서드
+     * 사용자 리뷰 생성 컨트롤러 메서드
      * @param lessonId 과외 식별자
      * @param suggestId 과외 신청 식별자
      * @param postReview 과외 신청 정보
@@ -32,6 +33,7 @@ public class reviewController {
     public ResponseEntity<?> postReview(@PathVariable("lesson-id") Long lessonId,
                                         @PathVariable("suggest-id") Long suggestId,
                                         @RequestBody PostReview postReview) {
+        // TODO : 시큐리티 적용 시 Authentication 객체 추가 요
         Long memberId = 1L; // 임시 하드 코딩 ㅎㅎ
         reviewService.createStudentReview(memberId, lessonId, suggestId, postReview);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -41,29 +43,55 @@ public class reviewController {
      * 과외 상세 페이지 리뷰 전체 조회 컨트롤러 메서드
      * @param lessonId 과외 식별자
      * @param pageable 페이지 정보
-     * @return MultiResponseDto
+     * @return MultiResponseDto(DetailInfoReviewList)
      * @author mozzi327
      */
     @GetMapping("/lesson/{lesson-id}")
-    public ResponseEntity<?> getDetailInfoReviews(@PathVariable("lesson-id") Long lessonId,
+    public ResponseEntity<MultiResponseDto> getDetailInfoReviews(@PathVariable("lesson-id") Long lessonId,
                                                   Pageable pageable) {
-        Page<GetReview> getReviewList = reviewService.findDetailInfoReviews(lessonId, pageable);
-        return ResponseEntity.ok().body(new MultiResponseDto<>(getReviewList));
+        Page<GetReview> getReviews = reviewService.findAllDetailInfoReviews(lessonId, pageable);
+        return ResponseEntity.ok().body(new MultiResponseDto<>(getReviews));
     }
 
+    /**
+     * 사용자 마이 페이지 리뷰 내역 조회 컨트롤러 메서드
+     * @param pageable 페이지 정보
+     * @return MultiResponseDto(MyPageReviewList)
+     * @author mozzi327
+     */
     @GetMapping
-    public ResponseEntity<?> getMypageReview() {
-        return ResponseEntity.status(HttpStatus.OK).build();
+    public ResponseEntity<MultiResponseDto> getMyPageReview(Pageable pageable) {
+        // TODO : 시큐리티 적용 시 Authentication 객체 추가 요
+        Long memberId = 1L; // 임시 하드 코딩 ㅎㅎ
+        Page<GetReviewMyPage> getReviews = reviewService.findAllMyPageReviews(memberId, pageable);
+        return ResponseEntity.ok().body(new MultiResponseDto<>(getReviews));
     }
 
+    /**
+     * 사용자 리뷰 수정 컨트롤러 메서드
+     * @param reviewId 리뷰 식별자
+     * @param patchReview 리뷰 수정 정보
+     * @author mozzi327
+     */
     @PatchMapping("/{review-id}/edit")
     public ResponseEntity<?> updateReview(@PathVariable("review-id") Long reviewId,
                                           @RequestBody PatchReview patchReview) {
-        return ResponseEntity.status(HttpStatus.OK).build();
+        // TODO : 시큐리티 적용 시 Authentication 객체 추가 요
+        Long memberId = 1L; // 임시 하드 코딩 ㅎㅎ
+        reviewService.editReview(memberId, reviewId, patchReview);
+        return ResponseEntity.ok().build();
     }
 
+    /**
+     * 사용자 리뷰 삭제 메서드
+     * @param reviewId 리뷰 식별자
+     * @author mozzi327
+     */
     @DeleteMapping("/{review-id}")
     public ResponseEntity<?> deleteReview(@PathVariable("review-id") Long reviewId) {
+        // TODO : 시큐리티 적용 시 Authentication 객체 추가 요
+        Long memberId = 1L; // 임시 하드 코딩 ㅎㅎ
+        reviewService.removeReview(memberId, reviewId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/dto/GetReviewMyPage.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/dto/GetReviewMyPage.java
@@ -1,0 +1,56 @@
+package com.codueon.boostUp.domain.reveiw.dto;
+
+import com.codueon.boostUp.domain.lesson.entity.Lesson;
+import com.codueon.boostUp.domain.reveiw.entity.Review;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetReviewMyPage {
+    private String profileImage;
+    private List<String> languages;
+    private String name;
+    private String title;
+    private String company;
+    private Integer career;
+    private Integer cost;
+    private List<String> address;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private Integer score;
+    private String comment;
+    private LocalDateTime createdAt;
+
+    @Builder
+    @QueryProjection
+    public GetReviewMyPage(Review review,
+                           Lesson lesson,
+                           LocalDateTime startTime,
+                           LocalDateTime endTime) {
+        this.profileImage = lesson.getProfileImage().getFilePath();
+        this.languages = lesson.getLessonLanguages().stream()
+                .map(language -> language.getLanguages().getLanguages())
+                .collect(Collectors.toList());
+        this.address = lesson.getLessonAddresses().stream()
+                .map(address -> address.getAdress().getAddress())
+                .collect(Collectors.toList());
+        this.name = lesson.getName();
+        this.title = lesson.getTitle();
+        this.company = lesson.getCompany();
+        this.career = lesson.getCareer();
+        this.cost = lesson.getCost();
+        this.startTime = startTime; // 야매
+        this.endTime = endTime; // 야매
+        this.score = review.getScore();
+        this.comment = review.getComment();
+        this.createdAt = review.getCreatedAt();
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/dto/PatchReview.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/dto/PatchReview.java
@@ -7,11 +7,11 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class PatchReview {
-    private Double score;
+    private Integer score;
     private String comment;
 
     @Builder
-    public PatchReview(Double score, String comment) {
+    public PatchReview(Integer score, String comment) {
         this.score = score;
         this.comment = comment;
     }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/entity/Review.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/entity/Review.java
@@ -1,5 +1,6 @@
 package com.codueon.boostUp.domain.reveiw.entity;
 
+import com.codueon.boostUp.domain.reveiw.dto.PatchReview;
 import com.codueon.boostUp.global.util.Auditable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -18,10 +20,10 @@ public class Review extends Auditable {
     @Column(name = "REVIEW")
     private Long id;
 
+    private Integer score;
+
     @Column(length = 1000)
     private String comment;
-
-    private Integer score;
 
     private Long lessonId;
 
@@ -34,5 +36,12 @@ public class Review extends Auditable {
         this.score = score;
         this.lessonId = lessonId;
         this.memberId = memberId;
+    }
+
+    public void editReview(PatchReview editReview) {
+        Optional.ofNullable(editReview.getScore())
+                .ifPresent(score -> this.score = score);
+        Optional.ofNullable(editReview.getComment())
+                .ifPresent(comment -> this.comment = comment);
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/CustomReviewRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/CustomReviewRepository.java
@@ -1,9 +1,11 @@
 package com.codueon.boostUp.domain.reveiw.repository;
 
 import com.codueon.boostUp.domain.reveiw.dto.GetReview;
+import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomReviewRepository {
     Page<GetReview> getReviewList(Long lessonId, Pageable pageable);
+    Page<GetReviewMyPage> getMyPageReviewList(Long memberId, Pageable pageable);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
     Optional<Review> findByLessonIdAndMemberId(Long lessonId, Long memberId);
+    Optional<Review> findByMemberIdAndId(Long memberId, Long reviewId);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepositoryImpl.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepositoryImpl.java
@@ -1,19 +1,22 @@
 package com.codueon.boostUp.domain.reveiw.repository;
 
 import com.codueon.boostUp.domain.reveiw.dto.GetReview;
+import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
 import com.codueon.boostUp.domain.reveiw.dto.QGetReview;
+import com.codueon.boostUp.domain.reveiw.dto.QGetReviewMyPage;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
 
+import static com.codueon.boostUp.domain.lesson.entity.QLesson.lesson;
 import static com.codueon.boostUp.domain.member.entity.QMember.member;
 import static com.codueon.boostUp.domain.member.entity.QMemberImage.memberImage;
 import static com.codueon.boostUp.domain.reveiw.entity.QReview.review;
+import static com.codueon.boostUp.domain.suggest.entity.QSuggest.suggest;
 
 public class ReviewRepositoryImpl implements CustomReviewRepository {
 
@@ -39,6 +42,27 @@ public class ReviewRepositoryImpl implements CustomReviewRepository {
                 .limit(pageable.getPageSize())
                 .orderBy(review.id.desc())
                 .fetch();
+        long total = result.size();
+        return new PageImpl<>(result, pageable, total);
+    }
+
+    @Override
+    public Page<GetReviewMyPage> getMyPageReviewList(Long memberId, Pageable pageable) {
+        List<GetReviewMyPage> result = queryFactory
+                .select(new QGetReviewMyPage(
+                        review,
+                        lesson,
+                        suggest.startTime,
+                        suggest.endTime
+                )).from(review)
+                .leftJoin(lesson).on(review.lessonId.eq(lesson.id))
+                .leftJoin(suggest).on(review.memberId.eq(suggest.memberId))
+                .where(review.memberId.eq(memberId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(review.id.desc())
+                .fetch();
+
         long total = result.size();
         return new PageImpl<>(result, pageable, total);
     }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.codueon.boostUp.domain.reveiw.service;
 
 import com.codueon.boostUp.domain.reveiw.dto.GetReview;
+import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
+import com.codueon.boostUp.domain.reveiw.dto.PatchReview;
 import com.codueon.boostUp.domain.reveiw.dto.PostReview;
 import com.codueon.boostUp.domain.reveiw.entity.Review;
 import com.codueon.boostUp.domain.reveiw.repository.ReviewRepository;
@@ -13,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import static com.codueon.boostUp.domain.suggest.entity.Suggest.SuggestStatus.PAY_SUCCESS;
+import static com.codueon.boostUp.domain.suggest.entity.Suggest.SuggestStatus.END_OF_LESSON;
 
 @Slf4j
 @Service
@@ -22,11 +24,20 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final SuggestDbService suggestDbService;
 
+    /**
+     * 사용자 리뷰 작성 메서드
+     * @param memberId 사용자 식별자
+     * @param lessonId 과외 식별자
+     * @param suggestId 과외 신청 식별자
+     * @param postReview 리뷰 등록 정보
+     * @author mozzi327
+     */
     public void createStudentReview(Long memberId, Long lessonId, Long suggestId, PostReview postReview) {
         Suggest suggest = suggestDbService.ifExistsReturnSuggest(suggestId);
-        // 예외 처리
-//        if(!suggest.getStatus().equals(PAY_SUCCESS))
+        // 예외 처리 : 과외 종료 상태가 아닐 때
+//        if(!suggest.getStatus().equals(END_OF_LESSON))
 //            throw new BusinessLogicException(ExceptionCode.NOT_PAY_SUCCESS);
+        // 리뷰 내역이 이미 존재할 때 예외 처리
         ifExistReviewThrowException(lessonId, memberId);
 
         Review review = Review.builder()
@@ -39,23 +50,68 @@ public class ReviewService {
     }
 
     /**
-     * 과외 상세페이지 리뷰 전체 조회
+     * 과외 상세페이지 리뷰 전체 조회 메서드
      * @param lessonId 과외 식별자
      * @param pageable 페이지 정보
      * @return Page(GetReview)
      * @author mozzi327
      */
-    public Page<GetReview> findDetailInfoReviews(Long lessonId, Pageable pageable) {
+    public Page<GetReview> findAllDetailInfoReviews(Long lessonId, Pageable pageable) {
         return reviewRepository.getReviewList(lessonId, pageable);
     }
 
     /**
-     * 리뷰가 이미 작성되어 있는지 확인하는 메서드
+     * 사용자 마이페이지 리뷰 전체 조회 메서드
+     * @param memberId 사용자 식별자
+     * @param pageable 페이지 정보
+     * @return Page(GetReviewMyPage)
+     * @author mozzi327
+     */
+    public Page<GetReviewMyPage> findAllMyPageReviews(Long memberId, Pageable pageable) {
+        return reviewRepository.getMyPageReviewList(memberId, pageable);
+    }
+
+    /**
+     * 사용자 리뷰 수정 메서드
+     * @param reviewId 리뷰 식별자
+     * @param patchReview 리뷰 수정 정보
+     * @author mozzi327
+     */
+    public void editReview(Long memberId, Long reviewId, PatchReview patchReview) {
+        Review findReview = ifExistReturnReview(memberId, reviewId);
+        findReview.editReview(patchReview);
+        reviewRepository.save(findReview);
+    }
+
+    /**
+     * 사용자 리뷰 삭제 메서드
+     * @param reviewId 리뷰 식별자
+     * @author mozzi327
+     */
+    public void removeReview(Long memberId, Long reviewId) {
+        Review findReview = ifExistReturnReview(memberId, reviewId);
+        reviewRepository.delete(findReview);
+    }
+
+    /**
+     * 사용자 리뷰가 이미 작성되어 있는지 확인하는 메서드
      * @param lessonId 과외 식별자
      * @param memberId 페이지 정보
+     * @author mozzi327
      */
     private void ifExistReviewThrowException(Long lessonId, Long memberId) {
         if(reviewRepository.findByLessonIdAndMemberId(lessonId, memberId).isPresent())
             throw new BusinessLogicException(ExceptionCode.REVIEW_ONLY_ONE);
+    }
+
+    /**
+     * 사용자 리뷰 정보 조회 메서드
+     * @param reviewId 리뷰 식별자
+     * @return Review
+     * @author mozzi327
+     */
+    private Review ifExistReturnReview(Long memberId, Long reviewId) {
+        return reviewRepository.findByMemberIdAndId(memberId, reviewId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REVIEW_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## 추가 사항
* 사용자 마이페이지 리뷰 전체 조회(학생용)
* 리뷰 수정
* 리뷰 삭제

memberId를 임시로 하드코딩한 상태인데 Security 적용 시 Authentication 정보에서 memberId를 가져올 생각입니다. 
또한 다른 도메인의 기능이 아직 구현되지 않아 테스트를 작성 못하고 있는데 추후 완성이 된다면 테스트도 작성할 예정입니다.