### PR TITLE
feat: 실시간 채팅 초기 세팅 완료

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/chat/controller/ChatController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/controller/ChatController.java
@@ -1,0 +1,30 @@
+package com.codueon.boostUp.domain.chat.controller;
+
+import com.codueon.boostUp.domain.chat.dto.req.PostMessage;
+import com.codueon.boostUp.domain.chat.entity.RedisChat;
+import com.codueon.boostUp.domain.chat.redis.RedisPublisher;
+import com.codueon.boostUp.domain.chat.service.ChatService;
+import com.codueon.boostUp.domain.chat.service.RoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+    private final RedisPublisher redisPublisher;
+    private final ChatService chatService;
+    private final RoomService roomService;
+
+    @MessageMapping("/chats/message/{room-id}")
+    public void chat(@DestinationVariable("room-id") Long roomId, PostMessage message) {
+        LocalDateTime now = LocalDateTime.now();
+        redisPublisher.publishingTopic(ChannelTopic.of("room" + roomId), new RedisChat(roomId, message.getSenderId(),
+                message.getContent(), now));
+        chatService.save(roomId, message, now);
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/req/PostMessage.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/req/PostMessage.java
@@ -1,0 +1,26 @@
+package com.codueon.boostUp.domain.chat.dto.req;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class PostMessage {
+    @NotNull
+    private Long senderId;
+    @NotNull
+    private Long receiverId;
+    @NotBlank
+    private String content;
+
+    @Builder
+    public PostMessage(Long senderId, Long receiverId, String content) {
+        this.senderId = senderId;
+        this.receiverId = receiverId;
+        this.content = content;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/req/PostRoom.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/req/PostRoom.java
@@ -1,0 +1,22 @@
+package com.codueon.boostUp.domain.chat.dto.req;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class PostRoom {
+    @NotNull
+    private Long merchantId;
+    @NotNull
+    private Long studentId;
+
+    @Builder
+    public PostRoom(Long merchantId, Long studentId) {
+        this.merchantId = merchantId;
+        this.studentId = studentId;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChat.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChat.java
@@ -1,0 +1,41 @@
+package com.codueon.boostUp.domain.chat.dto.res;
+
+import com.codueon.boostUp.domain.chat.entity.ChatMessage;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GetChat {
+    private Long memberId;
+    private String profileImage;
+    private String name;
+    private String content;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public GetChat(Long memberId,
+                   String profileImage,
+                   String name,
+                   String content,
+                   LocalDateTime createdAt) {
+        this.memberId = memberId;
+        this.profileImage = profileImage;
+        this.name = name;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static GetChat of(ChatMessage chatMessage) {
+        return GetChat.builder()
+                .memberId(chatMessage.getSender().getId())
+                .profileImage(chatMessage.getSender().getMemberImage().getFilePath())
+                .name(chatMessage.getSender().getName())
+                .content(chatMessage.getContent())
+                .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChatMember.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChatMember.java
@@ -1,0 +1,20 @@
+package com.codueon.boostUp.domain.chat.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetChatMember {
+    private Long memberId;
+    private String profileImage;
+    private String name;
+
+    @Builder
+    public GetChatMember(Long memberId, String profileImage, String name) {
+        this.memberId = memberId;
+        this.profileImage = profileImage;
+        this.name = name;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChatRoom.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetChatRoom.java
@@ -1,0 +1,32 @@
+package com.codueon.boostUp.domain.chat.dto.res;
+
+import com.codueon.boostUp.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class GetChatRoom {
+    private List<GetChatMember> members;
+    List<GetChat> chatResponses;
+
+    @Builder
+    public GetChatRoom(Member memberA, Member memberB, List<GetChat> chatResponses) {
+        this.members = List.of(
+                GetChatMember.builder()
+                        .memberId(memberA.getId())
+                        .profileImage(memberA.getMemberImage().getFilePath())
+                        .name(memberA.getName())
+                        .build(),
+                GetChatMember.builder()
+                        .memberId(memberB.getId())
+                        .profileImage(memberB.getMemberImage().getFilePath())
+                        .name(memberB.getName())
+                        .build()
+        );
+        this.chatResponses = chatResponses;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetLastChat.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/dto/res/GetLastChat.java
@@ -1,0 +1,50 @@
+package com.codueon.boostUp.domain.chat.dto.res;
+
+import com.codueon.boostUp.domain.chat.entity.ChatMessage;
+import com.codueon.boostUp.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class GetLastChat {
+    private Long roomId;
+    private Long merchantId;
+    private Long studentId;
+    private String name;
+    private String latestMessage;
+    private LocalDateTime createdAt;
+    private String profileImage;
+
+    @Builder
+    public GetLastChat(Long roomId,
+                       Long merchantId,
+                       Long studentId,
+                       String name,
+                       String latestMessage,
+                       LocalDateTime createdAt,
+                       String profileImage) {
+        this.roomId = roomId;
+        this.merchantId = merchantId;
+        this.studentId = studentId;
+        this.name = name;
+        this.latestMessage = latestMessage;
+        this.createdAt = createdAt;
+        this.profileImage = profileImage;
+    }
+
+    public static GetLastChat of(Member partner, ChatMessage latestChat) {
+        return GetLastChat.builder()
+                .roomId(latestChat.getRoom().getId())
+                .merchantId(latestChat.getRoom().getMerchant().getId())
+                .studentId(latestChat.getRoom().getStudent().getId())
+                .name(partner.getName())
+                .profileImage(partner.getMemberImage().getFilePath())
+                .latestMessage(latestChat.getContent())
+                .createdAt(latestChat.getCreatedAt())
+                .build();
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/entity/ChatMessage.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,49 @@
+package com.codueon.boostUp.domain.chat.entity;
+
+import com.codueon.boostUp.domain.member.entity.Member;
+import com.codueon.boostUp.global.util.Auditable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends Auditable {
+
+    @Id
+    @Column(name = "CHAT_MESSAGE_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_chat_to_sender"))
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_room_to_receiver"))
+    private Member receiver;
+
+    @Column(length = 5000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room")
+    private ChatRoom room;
+
+    @Builder
+    public ChatMessage(Long id,
+                       Member sender,
+                       Member receiver,
+                       String content,
+                       ChatRoom room) {
+        this.id = id;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.content = content;
+        this.room = room;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/entity/ChatRoom.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,37 @@
+package com.codueon.boostUp.domain.chat.entity;
+
+import com.codueon.boostUp.domain.member.entity.Member;
+import com.codueon.boostUp.global.util.Auditable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends Auditable implements Serializable {
+
+    @Id
+    @Column(name = "CHAT_ROOM_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_room_to_merchant"))
+    private Member merchant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, foreignKey = @ForeignKey(name = "fk_room_to_student"))
+    private Member student;
+
+    @Builder
+    public ChatRoom(Long id, Member merchant, Member student) {
+        this.id = id;
+        this.merchant = merchant;
+        this.student = student;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/entity/RedisChat.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/entity/RedisChat.java
@@ -1,0 +1,43 @@
+package com.codueon.boostUp.domain.chat.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RedisChat {
+
+    @NotNull
+    private Long roomId;
+
+    @NotNull
+    private Long senderId;
+
+    @NotBlank
+    private String message;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RedisChat(Long roomId,
+                     Long senderId,
+                     String message,
+                     LocalDateTime createdAt) {
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.message = message;
+        this.createdAt = createdAt;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/redis/RedisPublisher.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/redis/RedisPublisher.java
@@ -1,0 +1,20 @@
+package com.codueon.boostUp.domain.chat.redis;
+
+import com.codueon.boostUp.domain.chat.entity.RedisChat;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisPublisher {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void publishingTopic(ChannelTopic topic, RedisChat message) {
+        redisTemplate.convertAndSend(topic.getTopic(), message);
+        log.info("레디스 송신 완료");
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/redis/RedisSubscriber.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/redis/RedisSubscriber.java
@@ -1,0 +1,35 @@
+package com.codueon.boostUp.domain.chat.redis;
+
+import com.codueon.boostUp.domain.chat.entity.RedisChat;
+import com.codueon.boostUp.global.exception.BusinessLogicException;
+import com.codueon.boostUp.global.exception.ExceptionCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate redisTemplate;
+    private final SimpMessageSendingOperations messageSendingOperations;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String publishMessage = String.valueOf(redisTemplate.getStringSerializer().deserialize(message.getBody()));
+            RedisChat redisChat = objectMapper.readValue(publishMessage, RedisChat.class);
+            messageSendingOperations.convertAndSend("/sub/room/" + redisChat.getRoomId(), redisChat);
+            log.info("메시지를 레디스에 받아옵니다.");
+        } catch (Exception e) {
+            throw new BusinessLogicException(ExceptionCode.CHAT_NOT_FOUND);
+        }
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/repository/ChatRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/repository/ChatRepository.java
@@ -1,0 +1,58 @@
+package com.codueon.boostUp.domain.chat.repository;
+
+import com.codueon.boostUp.domain.chat.entity.ChatMessage;
+import com.codueon.boostUp.domain.chat.entity.ChatRoom;
+import com.codueon.boostUp.domain.chat.redis.RedisSubscriber;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Repository;
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import static com.codueon.boostUp.domain.chat.entity.QChatMessage.chatMessage;
+import static com.codueon.boostUp.domain.chat.entity.QChatRoom.chatRoom;
+
+@Repository
+public class ChatRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final RedisSubscriber redisSubscriber;
+
+    public ChatRepository(EntityManager em,
+                          RedisMessageListenerContainer redisMessageListenerContainer,
+                          RedisSubscriber redisSubscriber) {
+        this.jpaQueryFactory = new JPAQueryFactory(em);
+        this.redisMessageListenerContainer = redisMessageListenerContainer;
+        this.redisSubscriber = redisSubscriber;
+    }
+
+    public List<ChatMessage> findAllLatestChats(List<ChatRoom> rooms) {
+        return jpaQueryFactory
+                .selectFrom(chatMessage)
+                .where(Expressions.list(chatMessage.room, chatMessage.createdAt)
+                        .in((JPAExpressions
+                                .select(chatMessage.room, chatMessage.createdAt.max())
+                                .from(chatMessage)
+                                .where(chatMessage.room.in(rooms))
+                                .groupBy(chatMessage.room)
+                        )))
+                .orderBy(chatMessage.createdAt.desc())
+                .fetch();
+    }
+
+    public List<ChatMessage> findAllChatsInRoom(Long roomId) {
+        return jpaQueryFactory.select(chatMessage)
+                .from(chatMessage)
+                .where(chatMessage.room.id.eq(roomId))
+                .fetch();
+    }
+
+    public Optional<ChatRoom> getOrCreate(Long merChantId, Long studentId) {
+        return Optional.ofNullable(jpaQueryFactory
+                        .selectFrom(chatRoom)
+                        .where(chatRoom.student.id.eq(studentId).and(chatRoom.merchant.id.eq(merChantId)))
+                .fetchFirst());
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/repository/RoomRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/repository/RoomRepository.java
@@ -1,0 +1,11 @@
+package com.codueon.boostUp.domain.chat.repository;
+
+import com.codueon.boostUp.domain.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+public interface RoomRepository extends JpaRepository<ChatRoom, Long> {
+    List<ChatRoom> findByMerchantIdAndStudentId(Long merchantId, Long studentId);
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/service/ChatService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/service/ChatService.java
@@ -1,0 +1,36 @@
+package com.codueon.boostUp.domain.chat.service;
+
+import com.codueon.boostUp.domain.chat.dto.req.PostMessage;
+import com.codueon.boostUp.domain.chat.entity.ChatMessage;
+import com.codueon.boostUp.domain.chat.entity.ChatRoom;
+import com.codueon.boostUp.domain.chat.repository.ChatRepository;
+import com.codueon.boostUp.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+    private final ChatRepository chatRepository;
+    private final RoomService roomService;
+//    private final MemberDbService memberDbService;
+
+
+    public void save(Long roomId, PostMessage message, LocalDateTime now) {
+//        Member sender = memberDbService.findById(message.getSenderId());
+//        Member receiver = memberDbService.findById(message.getReceiverId());
+//        ChatRoom room = roomService.findById(roomId);
+//        ChatMessage chat = ChatMessage.builder()
+//                .sender(sender)
+//                .receiver(receiver)
+//                .content(message.getContent())
+//                .room(room)
+//                .build();
+//        chatRepository.save(chat);
+        // TODO : Alarm 호출 서비스 구현 요
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/chat/service/RoomService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/chat/service/RoomService.java
@@ -1,0 +1,26 @@
+package com.codueon.boostUp.domain.chat.service;
+
+import com.codueon.boostUp.domain.chat.redis.RedisSubscriber;
+import com.codueon.boostUp.domain.chat.repository.ChatRepository;
+import com.codueon.boostUp.domain.chat.repository.RoomRepository;
+import com.codueon.boostUp.domain.member.service.MemberDbService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+    private final ChatRepository chatRepository;
+    private final RoomRepository roomRepository;
+    private final MemberDbService memberDbService;
+    private final Map<String, ChannelTopic> topics;
+    private final RedisMessageListenerContainer redisMessageListener;
+    private final RedisSubscriber redisSubscriber;
+
+}

--- a/server/src/main/java/com/codueon/boostUp/global/config/RedisConfig.java
+++ b/server/src/main/java/com/codueon/boostUp/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.codueon.boostUp.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${redis.host}")
+    private String redisHost;
+
+    @Value("${redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory factory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(factory);
+        return container;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return redisTemplate;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/global/config/WebSocketConfig.java
+++ b/server/src/main/java/com/codueon/boostUp/global/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.codueon.boostUp.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/sub");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/stomp/chat")
+                .setAllowedOrigins(
+                        "http://localhost:3000",
+                        "https://codueon.com",
+                        "http://codueon.com",
+                        "http://localhost:8080",
+                        "https://server.codueon.com",
+                        "http://server.codueon.com"
+                ).withSockJS();
+    }
+}

--- a/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewPatchTest.java
+++ b/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewPatchTest.java
@@ -36,6 +36,5 @@ public class ReviewPatchTest extends ReviewControllerTest {
 
         actions.andExpect(status().isOk())
                 .andReturn();
-
     }
 }


### PR DESCRIPTION
## 추가 사항
### 📌 엔티티
* ChatRoom
* ChatMessage
* RedisChat

### 📌 Config 파일
* 실시간 채팅 RedisConfig
* WebSocketConfig

### 📌 Dto
* PostMessage
* PostRoom
* GetChat
* GetChatMember
* GetChatRoom
* GetLastChat

### 📌 Controller
* ChatController

### 📌 Service
* ChatService
* RoomServie

### 📌 Repository
* ChatRepository

### 📌 Redis
* RedisPublisher
* RedisSubscriber

채팅 관련 초기 세팅은 완료했고 (레디스 연결이랑 일단은 충돌없이 서버 실행됨) 세부적인 서비스 구현은 내일 진행해볼 예정입니다. 추후에 채팅 서버를 분리하던가 리팩토링하는 방법에 대해 아키텍처를 생각해보겠습니다.