### PR TITLE
feat: 인증페이지 재사용컴포넌트 구현

### DIFF
--- a/client/components/reuse/AuthBtn.tsx
+++ b/client/components/reuse/AuthBtn.tsx
@@ -1,0 +1,16 @@
+interface Props {
+    onClick : () => void;
+    children : React.ReactNode;
+}
+
+const AuthBtn = ({onClick, children}:Props) => {
+    return (
+        <>
+            <button className="font-SCDream4 w-1/4 py-2 bg-pointColor rounded-md text-white text-sm" onClick={onClick}>
+                {children}
+            </button>
+        </>
+    )
+}
+
+export default AuthBtn;

--- a/client/components/reuse/AuthContainer.tsx
+++ b/client/components/reuse/AuthContainer.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+const AuthContainer = ({ children }: Props) => {
+  return (
+    <>
+      <div className="flex flex-col justify-center items-center desktop:w-1/3 tablet:w-1/2 w-full min-h-[70%] h-fit bg-white p-10">
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default AuthContainer;

--- a/client/components/reuse/InputBox.tsx
+++ b/client/components/reuse/InputBox.tsx
@@ -1,0 +1,15 @@
+interface Props {
+    placeholder : string,
+    value : string,
+    onChange : (e:any) => void;
+}
+
+const InputBox = ({placeholder, value, onChange}:Props) => {
+    return (
+        <>
+            <input type="text" placeholder={placeholder} value={value} onChange={onChange} className="w-full h-fit p-2 border  border-borderColor outline-pointColor rounded-md font-SCDream2 text-sm text-textColor"></input>
+        </>
+    )
+}
+
+export default InputBox;

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -14,7 +14,7 @@
 
 @font-face {
   font-family: "SCDream3";
-  src: "../public/fonts/SCDream3.otf";
+  src: url("../public/fonts/SCDream3.otf");
 }
 
 @font-face {


### PR DESCRIPTION
### 구현사항
* AuthBtn : 인증페이지 내에 들어가는 버튼
* AuthContainer :  인증페이지 내에 들어가는 요소들을 감싸는 컨테이너
* InputBox : 인증페이지 내의 input 창