### PR TITLE
refactor: 마이페이지 조회 시 ProfileImage 나오도록 주석 삭제 및 PaymentInfo 중복 저장 방지 로직 추가

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/dto/GetStudentSuggest.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/dto/GetStudentSuggest.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +37,10 @@ public class GetStudentSuggest {
 
     private String status;
 
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
     @Builder
     @QueryProjection
     public GetStudentSuggest(Suggest suggest,
@@ -44,7 +49,7 @@ public class GetStudentSuggest {
         this.lessonId = lesson.getId();
         this.name = lesson.getName();
         this.title = lesson.getTitle();
-//        this.profileImage = lesson.getProfileImage().getFilePath();
+        this.profileImage = lesson.getProfileImage().getFilePath();
         this.company = lesson.getCompany();
         this.career = lesson.getCareer();
         this.cost = lesson.getCost();
@@ -55,5 +60,7 @@ public class GetStudentSuggest {
                 .map(address -> address.getAddress().getAddress())
                 .collect(Collectors.toList());
         this.status = suggest.getStatus().getStatus();
+        this.startTime = suggest.getStartTime();
+        this.endTime = suggest.getEndTime();
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/dto/GetSuggestInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/dto/GetSuggestInfo.java
@@ -45,7 +45,7 @@ public class GetSuggestInfo {
                 .map(address -> address.getAddress().getAddress())
                 .collect(Collectors.toList());
         this.company = lesson.getCompany();
-//        this.profileImage = lesson.getProfileImage().getFilePath();
+        this.profileImage = lesson.getProfileImage().getFilePath();
         this.cost = lesson.getCost();
         this.totalCost = totalCost;
         this.quantity = quantity;

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestDbService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestDbService.java
@@ -15,6 +15,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class SuggestDbService {
@@ -43,6 +45,16 @@ public class SuggestDbService {
     public PaymentInfo ifExistsReturnPaymentInfo(Long suggestId) {
         return paymentInfoRepository.findBySuggestId(suggestId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.RESERVATION_NOT_FOUND));
+    }
+
+    /**
+     * 결제 정보 조회 메서드 2 - 예외처리 X
+     * @param suggestId 신청 식별자
+     * @return PaymentInfo
+     * @author LeeGoh
+     */
+    public Optional<PaymentInfo> isPaymentInfo(Long suggestId) {
+        return paymentInfoRepository.findBySuggestId(suggestId);
     }
 
     /**
@@ -79,6 +91,15 @@ public class SuggestDbService {
      */
     public void deleteSuggest(Suggest suggest) {
         suggestRepository.delete(suggest);
+    }
+
+    /**
+     * 결제 정보 삭제 메서드
+     * @param paymentInfo 결제 정보
+     * @author LeeGoh
+     */
+    public void deletePaymentInfo(PaymentInfo paymentInfo) {
+        paymentInfoRepository.delete(paymentInfo);
     }
 
     /**

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
@@ -19,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import static com.codueon.boostUp.domain.suggest.entity.Suggest.SuggestStatus.END_OF_LESSON;
 import static com.codueon.boostUp.domain.suggest.utils.PayConstants.ORDER_APPROVED;
 import static com.codueon.boostUp.domain.suggest.utils.SuggestConstants.*;
@@ -43,7 +45,7 @@ public class SuggestService {
     @Transactional
     public void createSuggest(PostSuggest post, Long lessonId, Long memberId) {
 
-//        Lesson findLesson = lessonDbService.ifExistsReturnLesson(lessonId);
+        Lesson findLesson = lessonDbService.ifExistsReturnLesson(lessonId);
 
 //        if(memberId.equals(findLesson.getMemberId())) {
 //            throw new BusinessLogicException(ExceptionCode.TUTOR_CANNOT_RESERVATION);
@@ -53,7 +55,7 @@ public class SuggestService {
                 .days(post.getDays())
                 .languages(post.getLanguages())
                 .requests(post.getRequests())
-                .lessonId(lessonId)
+                .lessonId(findLesson.getId())
                 .memberId(memberId)
                 .build();
 
@@ -167,6 +169,11 @@ public class SuggestService {
         Suggest findSuggest = suggestDbService.ifExistsReturnSuggest(suggestId);
         Member findMember = memberDbService.ifExistsReturnMember(memberId);
         Lesson findLesson = lessonDbService.ifExistsReturnLesson(findSuggest.getLessonId());
+
+        Optional<PaymentInfo> findPaymentInfo = suggestDbService.isPaymentInfo(suggestId);
+        if (findPaymentInfo.isPresent()) {
+            suggestDbService.deletePaymentInfo(findPaymentInfo.get());
+        }
 
         KakaoPayHeader headers = feignService.setHeaders();
         ReadyToPaymentInfo params = feignService.setReadyParams(requestUrl, findSuggest, findMember, findLesson);


### PR DESCRIPTION
## 수정 사항
- 마이페이지 학생용 조회 시 startTime, endTime 반환하도록 DTO에 추가
- 마이페이지 조회 시 ProfileImage 나오도록 주석 삭제
- 존재하지 않는 과외 신청 시 에러 발생하도록 수정
- PaymentInfo 중복 저장 방지
  ```
  Optional<PaymentInfo> findPaymentInfo = suggestDbService.isPaymentInfo(suggestId);
        if (findPaymentInfo.isPresent()) {
            suggestDbService.deletePaymentInfo(findPaymentInfo.get());
        }
  ```