### PR TITLE
feat: Toss 결제 URL 요청 기능 구현 및 카카오페이 결제 코드 수정

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
@@ -88,12 +88,12 @@ public class SuggestController {
     }
 
     /**
-     * 신청 프로세스 4 결제 URL 요청 컨트롤러 메서드
+     * 신청 프로세스 4 결제 URL 요청 컨트롤러 메서드 Kakao
      * @param suggestId 신청 식별자
      * @return Message
      * @author LeeGoh
      */
-    @GetMapping("/lesson/suggest/{suggest-id}/payment")
+    @GetMapping("/lesson/suggest/{suggest-id}/kakao/payment")
     public ResponseEntity<Message<?>> orderPayment(@PathVariable("suggest-id") Long suggestId,
                                        HttpServletRequest request) {
 
@@ -105,17 +105,34 @@ public class SuggestController {
     }
 
     /**
+     * 신청 프로세스 4 결제 URL 요청 컨트롤러 메서드 Toss
+     * @param suggestId 신청 식별자
+     * @return Message
+     * @author LeeGoh
+     */
+    @GetMapping("/lesson/suggest/{suggest-id}/toss/payment")
+    public ResponseEntity<Message<?>> orderPaymentWithToss(@PathVariable("suggest-id") Long suggestId,
+                                                           HttpServletRequest request) {
+
+        Long memberId = 1L;
+        String requestUrl = request.getRequestURL().toString().replace(request.getRequestURI(), "");
+        Message<?> message = suggestService.getTossPayUrl(suggestId, memberId, requestUrl);
+        if (message.getData() == null) suggestService.getFailedPayMessage();
+        return ResponseEntity.ok().body(message);
+    }
+
+    /**
      * 신청 프로세스 5 결제 성공 컨트롤러 메서드
      * @param suggestId 신청 식별자
      * @param pgToken Payment Gateway Token
      * @return Message
      * @author LeeGoh
      */
-    @GetMapping("/api/suggest/{suggest-id}/completed")
+    @GetMapping("/api/suggest/{suggest-id}/kakao/completed")
     public ResponseEntity<Message<?>> successPayment(@PathVariable("suggest-id") Long suggestId,
                                                      @RequestParam("pg_token") String pgToken) {
 
-        Message<?> message = suggestService.getSuccessPaymentInfo(suggestId, pgToken);
+        Message<?> message = suggestService.getSuccessKakaoPaymentInfo(suggestId, pgToken);
         if (message.getData() == null) suggestService.getFailedPayMessage();
         return ResponseEntity.ok().build();
     }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/entity/PaymentInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/entity/PaymentInfo.java
@@ -1,6 +1,7 @@
 package com.codueon.boostUp.domain.suggest.entity;
 
-import com.codueon.boostUp.domain.suggest.pay.ReadyToPaymentInfo;
+import com.codueon.boostUp.domain.suggest.pay.ReadyToKakaoPaymentInfo;
+import com.codueon.boostUp.domain.suggest.pay.ReadyToTossPaymentInfo;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,10 @@ public class PaymentInfo {
     @Column(name = "PAYMENT_ID")
     private Long id;
 
+    private Integer quantity;
+
+    /* ---------- 카카오 ---------- */
+
     private String cid;
 
     private String tid;
@@ -28,8 +33,6 @@ public class PaymentInfo {
 
     private String itemName;
 
-    private Integer quantity;
-
     private Integer totalAmount;
 
     private Integer valAmount;
@@ -38,24 +41,38 @@ public class PaymentInfo {
 
     private String approvalUrl;
 
+    private String cancelUrl;
+
+    /* ---------- 공통 ---------- */
+
     private String failUrl;
 
-    private String cancelUrl;
+    /* ---------- 토스 ---------- */
+
+    private Integer amount;
+
+    private String orderId;
+
+    private String orderName;
+
+    private String successUrl;
+
+    /* -------------------- */
 
     @OneToOne
     @JoinColumn(name = "SUGGEST_ID")
     private Suggest suggest;
-
-    public void setQuantity(Integer quantity) {
-        this.quantity = quantity;
-    }
 
     public void setSuggest(Suggest suggest) {
         this.suggest = suggest;
     }
 
     @Builder
-    public PaymentInfo(ReadyToPaymentInfo params, String tid) {
+    public PaymentInfo(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public void setKakaoPaymentInfo(ReadyToKakaoPaymentInfo params, String tid) {
         this.cid = params.getCid();
         this.tid = tid;
         this.partnerOrderId = params.getPartner_order_id();
@@ -68,5 +85,13 @@ public class PaymentInfo {
         this.approvalUrl = params.getApproval_url();
         this.failUrl = params.getFail_url();
         this.cancelUrl = params.getCancel_url();
+    }
+
+    public void setTossPaymentInfo(ReadyToTossPaymentInfo body) {
+        this.failUrl = body.getFailUrl();
+        this.amount = body.getAmount();
+        this.orderId = body.getOrderId();
+        this.orderName = body.getOrderName();
+        this.successUrl = body.getSuccessUrl();
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/entity/Suggest.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/entity/Suggest.java
@@ -32,8 +32,6 @@ public class Suggest {
 
     private Long memberId;
 
-    private Integer quantity;
-
     private Integer totalCost;
 
     private LocalDateTime startTime;
@@ -49,10 +47,6 @@ public class Suggest {
 
     public void setEndTime() {
         this.endTime = LocalDateTime.now();
-    }
-
-    public void setQuantity(Integer quantity) {
-        this.quantity = quantity;
     }
 
     public void setTotalCost(Integer totalCost) {

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/feign/KakaoPayFeignClient.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/feign/KakaoPayFeignClient.java
@@ -1,9 +1,9 @@
 package com.codueon.boostUp.domain.suggest.feign;
 
-import com.codueon.boostUp.domain.suggest.pay.PayReadyInfo;
-import com.codueon.boostUp.domain.suggest.pay.PaySuccessInfo;
-import com.codueon.boostUp.domain.suggest.pay.ReadyToPaymentInfo;
-import com.codueon.boostUp.domain.suggest.pay.RequestForPaymentInfo;
+import com.codueon.boostUp.domain.suggest.pay.KakaoPayReadyInfo;
+import com.codueon.boostUp.domain.suggest.pay.KakaoPaySuccessInfo;
+import com.codueon.boostUp.domain.suggest.pay.ReadyToKakaoPaymentInfo;
+import com.codueon.boostUp.domain.suggest.pay.RequestForKakaoPaymentInfo;
 import com.codueon.boostUp.domain.suggest.utils.PayConstants;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.SpringQueryMap;
@@ -14,15 +14,15 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface KakaoPayFeignClient {
 
     @PostMapping(value = "/v1/payment/ready")
-    PayReadyInfo readyForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
-                                 @RequestHeader(PayConstants.ACCEPT) String accept,
-                                 @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
-                                 @SpringQueryMap ReadyToPaymentInfo paymentInfo);
+    KakaoPayReadyInfo readyForPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                      @RequestHeader(PayConstants.ACCEPT) String accept,
+                                      @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
+                                      @SpringQueryMap ReadyToKakaoPaymentInfo params);
 
     @PostMapping(value = "/v1/payment/approve")
-    PaySuccessInfo successForPayment(
+    KakaoPaySuccessInfo successForPayment(
             @RequestHeader(PayConstants.AUTHORIZATION) String authorization,
             @RequestHeader(PayConstants.ACCEPT) String accept,
             @RequestHeader(PayConstants.CONTENT_TYPE) String contentType,
-            @SpringQueryMap RequestForPaymentInfo query);
+            @SpringQueryMap RequestForKakaoPaymentInfo query);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/feign/TossPayFeignClient.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/feign/TossPayFeignClient.java
@@ -1,0 +1,20 @@
+package com.codueon.boostUp.domain.suggest.feign;
+
+import com.codueon.boostUp.domain.suggest.pay.ReadyToTossPaymentInfo;
+import com.codueon.boostUp.domain.suggest.pay.TossPayReadyInfo;
+import com.codueon.boostUp.domain.suggest.utils.PayConstants;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(value = "tosspay", url = "https://api.tosspayments.com", configuration = {FeignErrorConfig.class})
+public interface TossPayFeignClient {
+
+    @PostMapping(value = "/v1/payments", consumes = "application/json")
+    TossPayReadyInfo readyForTossPayment(@RequestHeader(PayConstants.AUTHORIZATION) String authorization,
+                                         @RequestHeader(value = "Content-Type") String contentType,
+                                         @RequestBody ReadyToTossPaymentInfo body);
+
+
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/Checkout.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/Checkout.java
@@ -1,0 +1,18 @@
+package com.codueon.boostUp.domain.suggest.pay;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Checkout {
+
+    private String url;
+
+    @Builder
+    public Checkout(String url) {
+        this.url = url;
+    }
+
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/KakaoPayReadyInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/KakaoPayReadyInfo.java
@@ -12,7 +12,7 @@ import java.util.Date;
 @Getter
 @NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class PayReadyInfo {
+public class KakaoPayReadyInfo {
 
     @JsonProperty("partner_order_id")
     private String partnerOrderId;
@@ -42,15 +42,15 @@ public class PayReadyInfo {
     private Date createdAt;
 
     @Builder
-    public PayReadyInfo(String partnerOrderId,
-                        String partnerUserId,
-                        String itemName,
-                        Integer quantity,
-                        Integer totalAmount,
-                        Integer taxFreeAmount,
-                        String tid,
-                        String nextRedirectPcUrl,
-                        Date createdAt) {
+    public KakaoPayReadyInfo(String partnerOrderId,
+                             String partnerUserId,
+                             String itemName,
+                             Integer quantity,
+                             Integer totalAmount,
+                             Integer taxFreeAmount,
+                             String tid,
+                             String nextRedirectPcUrl,
+                             Date createdAt) {
         this.partnerOrderId = partnerOrderId;
         this.partnerUserId = partnerUserId;
         this.itemName = itemName;

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/KakaoPaySuccessInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/KakaoPaySuccessInfo.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class PaySuccessInfo {
+public class KakaoPaySuccessInfo {
 
     private String aid;
     private String tid;

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/ReadyToKakaoPaymentInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/ReadyToKakaoPaymentInfo.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ReadyToPaymentInfo {
+public class ReadyToKakaoPaymentInfo {
 
     private String cid;
     private String partner_order_id;
@@ -21,17 +21,17 @@ public class ReadyToPaymentInfo {
     private String cancel_url;
 
     @Builder
-    public ReadyToPaymentInfo(String cid,
-                              String partner_order_id,
-                              String partner_user_id,
-                              String item_name,
-                              Integer quantity,
-                              Integer total_amount,
-                              Integer val_amount,
-                              Integer tax_free_amount,
-                              String approval_url,
-                              String fail_url,
-                              String cancel_url) {
+    public ReadyToKakaoPaymentInfo(String cid,
+                                   String partner_order_id,
+                                   String partner_user_id,
+                                   String item_name,
+                                   Integer quantity,
+                                   Integer total_amount,
+                                   Integer val_amount,
+                                   Integer tax_free_amount,
+                                   String approval_url,
+                                   String fail_url,
+                                   String cancel_url) {
         this.cid = cid;
         this.partner_order_id = partner_order_id;
         this.partner_user_id = partner_user_id;

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/ReadyToTossPaymentInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/ReadyToTossPaymentInfo.java
@@ -1,0 +1,37 @@
+package com.codueon.boostUp.domain.suggest.pay;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReadyToTossPaymentInfo {
+
+    private Integer amount;
+
+    private String failUrl;
+
+    private String method;
+
+    private String orderId;
+
+    private String orderName;
+
+    private String successUrl;
+
+    @Builder
+    public ReadyToTossPaymentInfo(Integer amount,
+                                  String failUrl,
+                                  String method,
+                                  String orderId,
+                                  String orderName,
+                                  String successUrl) {
+        this.amount = amount;
+        this.failUrl = failUrl;
+        this.method = method;
+        this.orderId = orderId;
+        this.orderName = orderName;
+        this.successUrl = successUrl;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/RequestForKakaoPaymentInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/RequestForKakaoPaymentInfo.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class RequestForPaymentInfo {
+public class RequestForKakaoPaymentInfo {
 
     private String cid;
     private String tid;
@@ -14,12 +14,12 @@ public class RequestForPaymentInfo {
     private String partner_order_id;
 
     @Builder
-    public RequestForPaymentInfo(String cid,
-                                 String tid,
-                                 String pg_token,
-                                 Integer total_amount,
-                                 String partner_user_id,
-                                 String partner_order_id) {
+    public RequestForKakaoPaymentInfo(String cid,
+                                      String tid,
+                                      String pg_token,
+                                      Integer total_amount,
+                                      String partner_user_id,
+                                      String partner_order_id) {
         this.cid = cid;
         this.tid = tid;
         this.pg_token = pg_token;

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/TossPayHeader.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/TossPayHeader.java
@@ -1,0 +1,20 @@
+package com.codueon.boostUp.domain.suggest.pay;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TossPayHeader {
+
+    private String adminKey;
+
+    private String contentType;
+
+    @Builder
+    public TossPayHeader(String adminKey, String contentType) {
+        this.adminKey = adminKey;
+        this.contentType = contentType;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/TossPayReadyInfo.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/pay/TossPayReadyInfo.java
@@ -1,0 +1,43 @@
+package com.codueon.boostUp.domain.suggest.pay;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TossPayReadyInfo {
+
+    private Integer totalAmount;
+
+    private String paymentKey;
+
+    private String method;
+
+    private String orderId;
+
+    private String orderName;
+
+    private Checkout checkout;
+
+    private String mId;
+
+    private String requestedAt;
+
+    public TossPayReadyInfo(Integer totalAmount,
+                            String paymentKey,
+                            String method,
+                            String orderId,
+                            String orderName,
+                            Checkout checkout,
+                            String mId,
+                            String requestedAt) {
+        this.totalAmount = totalAmount;
+        this.paymentKey = paymentKey;
+        this.method = method;
+        this.orderId = orderId;
+        this.orderName = orderName;
+        this.checkout = checkout;
+        this.mId = mId;
+        this.requestedAt = requestedAt;
+    }
+}

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/utils/PayConstants.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/utils/PayConstants.java
@@ -9,6 +9,7 @@ public class PayConstants {
     public static final String ACCEPT = "Accept";
     public static final String FAIL_URL = "fail_url";
     public static final String KAKAO_AK = "KakaoAK ";
+    public static final String TOSS_AK = "Basic ";
     public static final String PG_TOKEN = "pg_token";
     public static final String QUANTITY = "quantity";
     public static final String ITEM_NAME = "item_name";


### PR DESCRIPTION
## 구현 기능
- orderPaymentWithToss 토스 결제 URL 요청 기능 구현

## 수정 사항
- 기존 Payment 메서드 이름에 Kakao 추가하여 리팩토링
- 과외 신청 수락 시 PaymentInfo 저장 메서드 추가
- Suggest Entity에서 quantity 정보 제거