### PR TITLE
feat: 비밀번호변경 관련 이메일존재여부 확인기능 구현

### DIFF
--- a/client/apis/auth/postCheckEmail.tsx
+++ b/client/apis/auth/postCheckEmail.tsx
@@ -1,0 +1,21 @@
+import axios from "axios";
+
+interface Props {
+  email: string;
+}
+
+const postCheckEmail = ({ email }: Props) => {
+  const body = {
+    email: email,
+  };
+
+  return axios.post("/member/email/check", body, {
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    headers: {
+      "content-Type": `application/json`,
+      "ngrok-skip-browser-warning": "69420",
+    },
+  });
+};
+
+export default postCheckEmail;

--- a/client/components/auth/ResetPwCodeAuth.tsx
+++ b/client/components/auth/ResetPwCodeAuth.tsx
@@ -1,15 +1,16 @@
 import AuthBtn from "components/reuse/btn/AuthBtn";
 import { ErrorMessage } from "@hookform/error-message";
-import { Dispatch, useState, SetStateAction, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useRecoilState } from "recoil";
-import { findPwEmail } from "../../atoms/auth/authAtom";
+import { findPwEmail, resetPwStep } from "../../atoms/auth/authAtom";
 import usePostCodeAuth from "hooks/auth/usePostCodeAuth";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 const ResetPwCodeAuth = () => {
   const [email, setEmail] = useRecoilState<string>(findPwEmail);
+  const [step, setStep] = useRecoilState(resetPwStep);
   const [code, setCode] = useState<string>("");
 
   const {
@@ -35,9 +36,12 @@ const ResetPwCodeAuth = () => {
   useEffect(() => {
     if (isSuccess) {
       toast.success("인증에 성공하였습니다!", {
-        autoClose: 3000,
+        autoClose: 1500,
         position: toast.POSITION.TOP_RIGHT,
       });
+      setTimeout(() => {
+        setStep(3);
+      }, 1700);
     }
 
     if (isError) {

--- a/client/components/auth/ResetPwEmailAuth.tsx
+++ b/client/components/auth/ResetPwEmailAuth.tsx
@@ -1,13 +1,17 @@
 import AuthBtn from "components/reuse/btn/AuthBtn";
 import { ErrorMessage } from "@hookform/error-message";
-import { Dispatch, useState, SetStateAction } from "react";
 import { useForm } from "react-hook-form";
 import usePostAuthPw from "hooks/auth/usePostEmailAuth";
+import usePostCheckEmail from "hooks/auth/usePostCheckEmail";
 import { useRecoilState } from "recoil";
-import { findPwEmail } from "../../atoms/auth/authAtom";
+import { findPwEmail, resetPwStep } from "../../atoms/auth/authAtom";
+import { useEffect } from "react";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 const ResetPwEmailAuth = () => {
   const [email, setEmail] = useRecoilState<string>(findPwEmail);
+  const [step, setStep] = useRecoilState(resetPwStep);
 
   const {
     handleSubmit,
@@ -15,7 +19,8 @@ const ResetPwEmailAuth = () => {
     formState: { errors },
   } = useForm({ mode: "onBlur" });
 
-  const { mutate } = usePostAuthPw();
+  const { mutate: requestCode } = usePostAuthPw();
+  const { mutate: checkEmail, isSuccess, isError } = usePostCheckEmail();
 
   const handleEmailChange = (e: any) => {
     setEmail(e.target.value);
@@ -23,15 +28,36 @@ const ResetPwEmailAuth = () => {
 
   const onSubmit = (e: any) => {
     console.log("Success Submit!");
-    mutate({ email });
+    checkEmail({ email });
+    // requestCode({ email });
   };
 
   const failSubmit = (e: any) => {
     console.log("Fail Submit");
   };
 
+  useEffect(() => {
+    if (isSuccess) {
+      toast.success("인증번호를 발송하였습니다", {
+        autoClose: 1500,
+        position: toast.POSITION.TOP_RIGHT,
+      });
+      setTimeout(() => {
+        requestCode({ email });
+      }, 1700);
+    }
+
+    if (isError) {
+      toast.error("등록되지 않은 이메일입니다", {
+        autoClose: 3000,
+        position: toast.POSITION.TOP_RIGHT,
+      });
+    }
+  }, [isSuccess, isError]);
+
   return (
     <>
+      <ToastContainer />
       <form
         onSubmit={handleSubmit(onSubmit, failSubmit)}
         className="w-full h-fit"
@@ -65,7 +91,7 @@ const ResetPwEmailAuth = () => {
           }}
         />
         <div className="w-full h-fit flex flex-col justify-center items-center mt-7">
-          <AuthBtn onClick={handleSubmit}>다 음</AuthBtn>
+          <AuthBtn onClick={handleSubmit}>인증요청</AuthBtn>
         </div>
       </form>
     </>

--- a/client/hooks/auth/usePostCheckEmail.tsx
+++ b/client/hooks/auth/usePostCheckEmail.tsx
@@ -1,0 +1,15 @@
+import { useMutation } from "react-query";
+import postCheckEmail from "apis/auth/postCheckEmail";
+
+const usePostCheckEmail = () => {
+  return useMutation(postCheckEmail, {
+    onSuccess: (res: any) => {
+      console.log(res);
+    },
+    onError: (err: any) => {
+      console.log(err);
+    },
+  });
+};
+
+export default usePostCheckEmail;

--- a/client/hooks/auth/usePostCodeAuth.tsx
+++ b/client/hooks/auth/usePostCodeAuth.tsx
@@ -1,13 +1,13 @@
 import { useMutation } from "react-query";
 import postAuthCode from "apis/auth/postAuthCode";
-import { useRecoilState } from "recoil";
-import { resetPwStep } from "atoms/auth/authAtom";
+// import { useRecoilState } from "recoil";
+// import { resetPwStep } from "atoms/auth/authAtom";
 
 const usePostCodeAuth = () => {
-  const [step, setStep] = useRecoilState(resetPwStep);
+  // const [step, setStep] = useRecoilState(resetPwStep);
   return useMutation(postAuthCode, {
     onSuccess: (res: any) => {
-      setStep(3);
+      console.log(res);
     },
     onError: (err: any) => {
       console.log(err);


### PR DESCRIPTION
### 구현사항
- 비밀번호 변경 1단계에서 인증요청 버튼을 눌렀을 시 이메일 존재여부 확인 API 요청
- 이메일 존재여부 요청이 성공했을 경우 (등록된 이메일인 것을 확인) 이메일 인증코드 요청 API 요청
- toasify 알림창 활성화 타이밍 조정