### PR TITLE
feat: 상세페이지 재사용컴포넌트 구현

### DIFF
--- a/client/atoms/detail/detailAtom.tsx
+++ b/client/atoms/detail/detailAtom.tsx
@@ -1,0 +1,1 @@
+import { atom } from "recoil";

--- a/client/components/reuse/btn/DetailBtn.tsx
+++ b/client/components/reuse/btn/DetailBtn.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  children: React.ReactNode;
+  bold: boolean;
+  remove: boolean;
+  onClick: () => void;
+}
+const DetailBtn = ({ children, bold, remove, onClick }: Props) => {
+  return (
+    <button
+      type="button"
+      className={
+        bold
+          ? "w-full h-14 flex flex-col justify-center items-center font-SCDream4 bg-pointColor border border-borderColor text-lg text-white mx-3 rounded-xl mb-3"
+          : remove
+          ? "w-full h-14 flex flex-col justify-center items-center font-SCDream4 bg-negativeMessage border border-borderColor text-lg text-white mx-3 rounded-xl mb-3"
+          : "w-full h-14 flex flex-col justify-center items-center font-SCDream4 bg-white border border-borderColor text-lg text-textColor mx-3 rounded-xl mb-3"
+      }
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default DetailBtn;

--- a/client/components/reuse/btn/DetailTabBtn.tsx
+++ b/client/components/reuse/btn/DetailTabBtn.tsx
@@ -1,0 +1,27 @@
+import { Dispatch, SetStateAction } from "react";
+
+interface Props {
+  children: React.ReactNode;
+  bold: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const DetailTabBtn = ({ children, bold, onClick }: Props) => {
+  return (
+    <>
+      <button
+        type="button"
+        className={
+          bold
+            ? "w-48 tablet:h-14 h-12 bg-pointColor text-white font-SCDream7 flex flex-col justify-center items-center tablet:text-lg text-sm border border-borderColor rounded-t-2xl mr-3"
+            : "w-48 tablet:h-14 h-12 bg-white text-textColor font-SCDream4 flex flex-col justify-center items-center tablet:text-lg text-sm border border-borderColor rounded-t-2xl mr-3"
+        }
+        onClick={onClick}
+      >
+        {children}
+      </button>
+    </>
+  );
+};
+
+export default DetailTabBtn;

--- a/client/components/reuse/container/DetailContentContainer.tsx
+++ b/client/components/reuse/container/DetailContentContainer.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+const DetailContentContainer = ({ children }: Props) => {
+  return (
+    <div className="flex desktop:min-w-[80%] min-w-full min-h-[500px] h-fit rounded-tr-xl rounded-b-xl flex-row justify-start items-center bg-white border-2 border-borderColor">
+      {children}
+    </div>
+  );
+};
+
+export default DetailContentContainer;

--- a/client/components/reuse/container/DetailSummeryContainer.tsx
+++ b/client/components/reuse/container/DetailSummeryContainer.tsx
@@ -1,0 +1,13 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+const DetailSummeryContainer = ({ children }: Props) => {
+  return (
+    <div className="flex w-3/4 desktop:min-w-[1000px] min-w-[95%] min-h-[230px] desktop-h-[100px] h-fit rounded-xl flex-row justify-between items-center bg-white border-2 border-borderColor">
+      {children}
+    </div>
+  );
+};
+
+export default DetailSummeryContainer;

--- a/client/pages/detail/[id].tsx
+++ b/client/pages/detail/[id].tsx
@@ -1,0 +1,87 @@
+import { useRouter } from "next/router";
+import DetailSummeryContainer from "components/reuse/container/DetailSummeryContainer";
+import DetailTabBtn from "components/reuse/btn/DetailTabBtn";
+import DetailContentContainer from "components/reuse/container/DetailContentContainer";
+import DetailBtn from "components/reuse/btn/DetailBtn";
+import { useEffect, useState } from "react";
+
+const Detail = () => {
+  // lessonId 받아오기
+  const router = useRouter();
+  const lessonId = router.query.id;
+
+  const [tab, setTab] = useState(1);
+
+  const handleTabClick = (id: number) => {
+    setTab(id);
+  };
+
+  useEffect(() => {
+    // refetch 실행위치
+    // tab이 바뀔때마다 refetch 실행
+    if (tab === 1) {
+      // 상세정보 refetch
+    } else if (tab === 2) {
+      // 진행방식 refetch
+    } else if (tab === 3) {
+      // 과외후기 refetch
+    }
+  }, [tab]);
+
+  return (
+    <>
+      <div className="flex flex-col bg-bgColor items-center justify-start w-full h-screen pt-28">
+        <DetailSummeryContainer>{lessonId}</DetailSummeryContainer>
+        <div className="flex w-3/4 desktop:min-w-[1000px] min-w-[95%] h-fit rounded-xl flex-row justify-start items-center mt-5">
+          <DetailTabBtn
+            bold={tab === 1 ? true : false}
+            onClick={() => {
+              handleTabClick(1);
+            }}
+          >
+            상세정보
+          </DetailTabBtn>
+          <DetailTabBtn
+            bold={tab === 2 ? true : false}
+            onClick={() => {
+              handleTabClick(2);
+            }}
+          >
+            진행방식
+          </DetailTabBtn>
+          <DetailTabBtn
+            bold={tab === 3 ? true : false}
+            onClick={() => {
+              handleTabClick(3);
+            }}
+          >
+            과외후기
+          </DetailTabBtn>
+        </div>
+        <div className="desktop:min-w-[1000px] min-w-[95%] w-3/4 h-fit flex desktop:flex-row flex-col justify-start items-center">
+          <DetailContentContainer>
+            각 탭별 컴포넌트를 생성하여 넣어주세요!
+          </DetailContentContainer>
+          <div className="w-full h-full flex flex-col justify-start items-center pl-3">
+            {/* 각 버튼 안에는 디자인에 맞게 div 박스 넣어서 구현해주세요! */}
+            <DetailBtn bold={true} remove={false} onClick={() => {}}>
+              신청하기
+            </DetailBtn>
+            <DetailBtn bold={false} remove={false} onClick={() => {}}>
+              실시간채팅
+            </DetailBtn>
+            <DetailBtn bold={false} remove={false} onClick={() => {}}>
+              선생님 찜하기
+            </DetailBtn>
+
+            <DetailBtn bold={false} remove={true} onClick={() => {}}>
+              삭제하기
+            </DetailBtn>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Detail;


### PR DESCRIPTION
### 구현사항
- detail page 레이아웃 구현
- 상세페이지 탭 버튼 구현
- 상세페이지 프로필 컨테이너 구현
- 상세페이지 컨텐츠 컨테이너 구현
- 상세페이지 버튼 구현
- 상세페이지 용 Atom폴더 생성
(각 컴포넌트 별 사용법은 detail/[id].tsx 에 주석으로 달아놓았습니다! 궁금하신 사항은 저에게 연락주세요!)