### PR TITLE
Refactor/style nmodal#376

### DIFF
--- a/client/atoms/auth/authAtom.tsx
+++ b/client/atoms/auth/authAtom.tsx
@@ -1,4 +1,7 @@
 import { atom } from "recoil";
+import { recoilPersist } from "recoil-persist";
+
+const { persistAtom } = recoilPersist();
 
 const findPwEmail = atom({
   key: "findPwEmail",
@@ -19,4 +22,17 @@ const resetPwStep = atom<Number>({
   key: "resetPwStep",
   default: 1,
 });
-export { findPwEmail, signUpErrorMessage, loginErrorMessage, resetPwStep };
+
+const logUser = atom({
+  key: "logUser",
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export {
+  findPwEmail,
+  signUpErrorMessage,
+  loginErrorMessage,
+  resetPwStep,
+  logUser,
+};

--- a/client/atoms/index.tsx
+++ b/client/atoms/index.tsx
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const logUser = atom({
-  key: "logUser",
-  default: false,
-});

--- a/client/components/Footer/Footer.tsx
+++ b/client/components/Footer/Footer.tsx
@@ -16,7 +16,7 @@ const devAlias: string[] = Object.keys(devAdds);
 const Footer = () => {
   return (
     <footer className="w-full bg-textColor flex justify-center items-center">
-      <div className="bg-textColor w-full h-28 text-white font-SCDream5 px-1 py-1 flex flex-col justify-between tablet:flex-row tablet:items-center tablet:h-[281px] desktop:w-3/4 desktop:min-w-[1000px]">
+      <div className="bg-textColor w-full h-28 text-white font-SCDream5 px-1 py-1 flex flex-col justify-between tablet:flex-row tablet:items-center tablet:h-40 desktop:w-3/4 desktop:h-52 desktop:min-w-[1000px]">
         <div className="tablet:flex tablet:flex-col tablet:h-1/2 tablet:justify-around">
           <div className="text-base tablet:text-2xl">(주)코듀온</div>
           <div>

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -35,15 +35,15 @@ const Header = () => {
 
   return (
     <>
-      <header className="bg-bgColor font-SCDream5 w-full pt-4 fixed top-0 z-[1] h-[63px] tablet:h-[69px] desktop:w-3/4 desktop:min-w-[1000px] desktop:h-[87px] desktop:mt-0">
+      <header className="bg-bgColor font-SCDream5 w-full pt-4 fixed top-0 z-[1] h-fit desktop:w-3/4 desktop:min-w-[1000px] desktop:h-[87px] desktop:mt-0">
         <nav className="w-full h-full flex tablet:justify-center tablet:items-center desktop:justify-between">
           <div className="w-1/2 flex justify-start items-center ml-4 tablet:h-[40px] desktop:hidden">
-            <div className="w-[18px] tablet:w-[34.5px]">
+            <div className="w-8 tablet:w-[34.5px]">
               <IconExit />
             </div>
           </div>
-          <div className="w-1/6 h-full flex justify-center items-center desktop:justify-start desktop:items-end">
-            <div className="w-[57.91px] h-[30px] tablet:w-[142px] tablet:h-[69px] desktop:w-[142px] desktop:h-[72px]">
+          <div className="tablet:w-1/6 h-fit flex justify-center items-center desktop:justify-start desktop:items-end">
+            <div className="flex justify-center items-center w-28 tablet:w-[142px] h-[69px] h-min-[69px]">
               <Link href="/">
                 <Image src={Logo} alt="logo" />
               </Link>
@@ -51,7 +51,7 @@ const Header = () => {
           </div>
           <div className="w-1/2 flex justify-end items-center mr-4 tablet:h-[40px] desktop:hidden">
             <div
-              className="w-[18px] tablet:w-[34.5px]"
+              className="w-9 tablet:w-[34.5px]"
               onClick={e => setSeek(!seek)}
             >
               <IconMagnify fill={textColor} />

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -44,7 +44,9 @@ const Header = () => {
           </div>
           <div className="w-1/6 h-full flex justify-center items-center desktop:justify-start desktop:items-end">
             <div className="w-[57.91px] h-[30px] tablet:w-[142px] tablet:h-[69px] desktop:w-[142px] desktop:h-[72px]">
-              <Image src={Logo} alt="logo" />
+              <Link href="/">
+                <Image src={Logo} alt="logo" />
+              </Link>
             </div>
           </div>
           <div className="w-1/2 flex justify-end items-center mr-4 tablet:h-[40px] desktop:hidden">

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useRecoilState } from "recoil";
-import { logUser } from "atoms";
 import { SubmitHandler } from "react-hook-form";
 import { textColor } from "assets/color/color";
 import { IconExit, IconMagnify } from "assets/icon/";
@@ -9,7 +8,10 @@ import { powerWriteModal } from "atoms/main/mainAtom";
 import Image from "next/image";
 import Logo from "../../public/images/logo.png";
 import Link from "next/link";
-import WriteModal from "components/createModal/WriteModal";
+import { logUser } from "atoms/auth/authAtom";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import { useEffect } from "react";
 
 interface SearchData {
   name: string;
@@ -21,7 +23,7 @@ interface SearchData {
 }
 
 const Header = () => {
-  const [log, setLog] = useRecoilState(logUser);
+  const [log, setLog] = useRecoilState<boolean>(logUser);
   const [seek, setSeek] = useState(false);
   const [isPowerWrite, setIsPowerWrite] = useRecoilState(powerWriteModal);
 
@@ -33,12 +35,21 @@ const Header = () => {
     setIsPowerWrite(prev => !prev);
   };
 
+  const logOutEvent = () => {
+    localStorage.clear();
+    setLog(prev => !prev);
+    toast.success("로그아웃이 되었습니다", {
+      autoClose: 1500,
+      position: toast.POSITION.TOP_RIGHT,
+    });
+  };
+
   return (
     <>
       <header className="bg-bgColor font-SCDream5 w-full pt-4 fixed top-0 z-[1] h-fit desktop:w-3/4 desktop:min-w-[1000px] desktop:h-[87px] desktop:mt-0">
         <nav className="w-full h-full flex tablet:justify-center tablet:items-center desktop:justify-between">
           <div className="w-1/2 flex justify-start items-center ml-4 tablet:h-[40px] desktop:hidden">
-            <div className="w-8 tablet:w-[34.5px]">
+            <div className="w-8 tablet:w-[34.5px]" onClick={logOutEvent}>
               <IconExit />
             </div>
           </div>
@@ -72,10 +83,7 @@ const Header = () => {
               {log ? (
                 <>
                   <div className="min-w-fit mr-8 py-1">마이페이지</div>
-                  <div
-                    className="min-w-fit mr-8 py-1"
-                    onClick={e => setLog(!log)}
-                  >
+                  <div className="min-w-fit mr-8 py-1" onClick={logOutEvent}>
                     로그아웃
                   </div>
                   <div
@@ -87,7 +95,7 @@ const Header = () => {
                 </>
               ) : (
                 <>
-                  <div className="mr-8" onClick={e => setLog(!log)}>
+                  <div className="mr-8">
                     <Link href="/login">로그인</Link>
                   </div>
                   <div>

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -57,7 +57,7 @@ const Header = () => {
               <IconMagnify fill={textColor} />
             </div>
           </div>
-          <div className="relative hidden desktop:flex desktop:items-end desktop:w-6/12 h-full">
+          <div className="hidden desktop:flex desktop:items-end desktop:w-min-[500px] desktop:w-[648px] desktop:h-full desktop:relative desktop:visible">
             <div
               className={`w-full h-[50px] flex justify-center items-center border border-borderColor outline-pointColor font-SCDream2 text-sm text-textColor bg-white 
              ${seek ? `rounded-tr-xl rounded-tl-xl` : `rounded-xl`}`}
@@ -65,7 +65,7 @@ const Header = () => {
             >
               <div>조건에 맞는 과외선생님을 찾아보세요</div>
             </div>
-            {seek && <SearchPop onSubmit={onSubmit} absolute={true} />}
+            {/* {seek && <SearchPop onSubmit={onSubmit} />} */}
           </div>
           <div className="w-1/5 h-full hidden desktop:flex desktop:flex-row-reverse desktop:items-end">
             <div className="w-full pt-2 desktop:flex desktop:h-[50px] desktop:justify-end text-sm">
@@ -98,13 +98,12 @@ const Header = () => {
             </div>
           </div>
         </nav>
+        {seek && (
+          <div className="absolute top-40">
+            <SearchPop onSubmit={onSubmit} />
+          </div>
+        )}
       </header>
-      {seek && (
-        <div className="absolute top-40 desktop:hidden">
-          <SearchPop onSubmit={onSubmit} absolute={false} />
-        </div>
-      )}
-      {isPowerWrite && <WriteModal />}
     </>
   );
 };

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -5,10 +5,10 @@ import { SubmitHandler } from "react-hook-form";
 import { textColor } from "assets/color/color";
 import { IconExit, IconMagnify } from "assets/icon/";
 import { SearchPop } from "./SearchPop";
+import { powerWriteModal } from "atoms/main/mainAtom";
 import Image from "next/image";
 import Logo from "../../public/images/logo.png";
 import Link from "next/link";
-import { powerWriteModal } from "atoms/main/mainAtom";
 import WriteModal from "components/createModal/WriteModal";
 
 interface SearchData {
@@ -23,14 +23,14 @@ interface SearchData {
 const Header = () => {
   const [log, setLog] = useRecoilState(logUser);
   const [seek, setSeek] = useState(false);
-  const [powerWrite, setPowerIsWrite] = useRecoilState(powerWriteModal);
+  const [isPowerWrite, setIsPowerWrite] = useRecoilState(powerWriteModal);
 
   const onSubmit: SubmitHandler<SearchData> = data => {
     console.log(data);
   };
 
   const toWrite = (e: React.MouseEvent<HTMLDivElement>) => {
-    setPowerIsWrite(prev => !prev);
+    setIsPowerWrite(prev => !prev);
   };
 
   return (
@@ -104,7 +104,7 @@ const Header = () => {
           <SearchPop onSubmit={onSubmit} absolute={false} />
         </div>
       )}
-      {powerWrite && <WriteModal />}
+      {isPowerWrite && <WriteModal />}
     </>
   );
 };

--- a/client/components/Header/SearchPop.tsx
+++ b/client/components/Header/SearchPop.tsx
@@ -6,10 +6,9 @@ import Select from "react-select";
 
 interface Props {
   onSubmit: any;
-  absolute?: boolean;
 }
 
-export const SearchPop = ({ onSubmit, absolute }: Props) => {
+export const SearchPop = ({ onSubmit }: Props) => {
   const { control, register, handleSubmit } = useForm();
   const [isAdd, setIsAdd] = useState(false);
   const [isLang, setIsLang] = useState(false);
@@ -19,7 +18,7 @@ export const SearchPop = ({ onSubmit, absolute }: Props) => {
 
   return (
     <div
-      className={`bg-white desktop:absolute tablet:top-[8px] desktop:top-[86px] desktop:w-full h-fit border border-borderColor rounded-br-xl rounded-bl-xl`}
+      className={`fixed h-fit border visible border-borderColor rounded-br-xl rounded-bl-xl bg-white tablet:left-[100px] tablet:top-[100px] desktop:absolute desktop:top-[70px] desktop:w-full`}
     >
       <form
         className="flex flex-col justify-center items-center"

--- a/client/components/Navbar/Navbar.tsx
+++ b/client/components/Navbar/Navbar.tsx
@@ -50,7 +50,7 @@ const Navbar = () => {
 
   useEffect(() => {
     if (mounted.current) {
-      toast.success("글이 성공적으로 작성되었습니다", {
+      toast.success("과외가 성공적으로 등록되었습니다", {
         autoClose: 1500,
         position: toast.POSITION.TOP_RIGHT,
       });

--- a/client/components/Navbar/Navbar.tsx
+++ b/client/components/Navbar/Navbar.tsx
@@ -5,14 +5,13 @@ import {
   IconProfile,
   IconPlus,
 } from "assets/icon/";
+import { useEffect, useRef } from "react";
 import { filterModal, isWrite, powerWriteModal } from "atoms/main/mainAtom";
-import WriteModal from "components/createModal/WriteModal";
-import Link from "next/link";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { toast, ToastContainer } from "react-toastify";
+import WriteModal from "components/createModal/WriteModal";
+import Link from "next/link";
 import "react-toastify/dist/ReactToastify.css";
-import { useEffect } from "react";
-import usePostWrite from "hooks/usePostWrite";
 
 const navContents = [
   {
@@ -41,18 +40,28 @@ const navContents = [
 ];
 
 const Navbar = () => {
-  const [powerWrite, setPowerIsWrite] = useRecoilState(powerWriteModal);
+  const [isPowerWrite, setIsPowerWrite] = useRecoilState(powerWriteModal);
   const [modal, setModal] = useRecoilState(filterModal);
-  const [isWritten, setIsWritten] = useRecoilState(isWrite);
+  const isWritten = useRecoilValue(isWrite);
+  const mounted = useRef(false);
   const toWrite = (e: React.MouseEvent<HTMLDivElement>) => {
-    setPowerIsWrite(prev => !prev);
+    setIsPowerWrite(prev => !prev);
   };
 
-  /** 연휴 서버 켜져있을 때 테스트할 것
-   * Modal이 제출되고 ModalBackDrop이 사라지고 메인 화면에 제출 완료라는 알람이 떴으면 좋겠음
-   * 따라서, 메인과 연관되어 있는 네브바에서 props drilling을 통해 mutate함수를 curriculum까지 내려주고 isSuccess를 받게 되면 현 문서에서 alert를 출력하는 것을 구현 예정
-   * **/
-  const { mutate, isSuccess, isError } = usePostWrite();
+  useEffect(() => {
+    if (mounted.current) {
+      toast.success("글이 성공적으로 작성되었습니다", {
+        autoClose: 1500,
+        position: toast.POSITION.TOP_RIGHT,
+      });
+    }
+  }, [isWritten]);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   // 하단 Navbar의 필터 버튼 클릭시 10~16줄 코드를 넣어주시면 됩니다!
   const handleModalClick = () => {
@@ -66,7 +75,7 @@ const Navbar = () => {
   return (
     <>
       <ToastContainer />
-      {powerWrite && <WriteModal mutate={mutate} />}
+      {isPowerWrite && <WriteModal />}
       <div className="bg-white w-full h-16 flex justify-center items-center sticky bottom-0  desktop:hidden">
         {navContents.map((content, i) => (
           <div key={i} className="w-1/5 flex justify-center items-center">

--- a/client/components/createModal/Curriculum.tsx
+++ b/client/components/createModal/Curriculum.tsx
@@ -11,16 +11,15 @@ import { langDict } from "components/reuse/dict";
 import usePostWrite from "hooks/usePostWrite";
 import { useEffect } from "react";
 import { isWrite } from "atoms/main/mainAtom";
-import { AxiosResponse } from "axios";
-import { UseMutateFunction } from "react-query";
+import { toast, ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 interface Props {
   basicInfo: Info;
-  addInfo: Info;
+  extraInfo: Info;
   curInfo: string;
   setCurInfo: Dispatch<SetStateAction<string>>;
   setStep: SetterOrUpdater<number>;
-  isPowerWrite: boolean;
   setIsPowerWrite: SetterOrUpdater<boolean>;
 }
 
@@ -34,11 +33,10 @@ const MDEditor = dynamic(() => import("@uiw/react-md-editor"), {
 
 const Curriculum = ({
   basicInfo,
-  addInfo,
+  extraInfo,
   curInfo,
   setCurInfo,
   setStep,
-  isPowerWrite,
   setIsPowerWrite,
 }: Props) => {
   const setIsWritten = useSetRecoilState(isWrite);
@@ -56,9 +54,14 @@ const Curriculum = ({
       console.log("성공");
       setIsPowerWrite(prev => !prev);
       setIsWritten(prev => !prev);
+      setStep(prev => prev - 2);
     }
     if (isError) {
       console.log("실패");
+      toast.error("과외를 다시 등록해주세요", {
+        autoClose: 1500,
+        position: toast.POSITION.TOP_RIGHT,
+      });
     }
   }),
     [isSuccess, isError];
@@ -80,7 +83,7 @@ const Curriculum = ({
       detailImage,
       introduction,
       personality,
-    } = addInfo;
+    } = extraInfo;
     const proImage = profileImg[0];
     const parseAddress = address.map((el: any) => el.value);
     const parseLang = language.map((el: any) => langDict[el]);
@@ -126,6 +129,7 @@ const Curriculum = ({
 
   return (
     <>
+      <ToastContainer />
       <div className="flex flex-col justify-center items-center w-full h-fit">
         <div className="w-fit h-fit font-SCDream5 desktop:text-sm tablet:text-sm text-[13.5px] text-pointColor">
           과외 진행방식에 대한 자세한 정보를 입력하세요

--- a/client/components/createModal/Curriculum.tsx
+++ b/client/components/createModal/Curriculum.tsx
@@ -20,14 +20,8 @@ interface Props {
   curInfo: string;
   setCurInfo: Dispatch<SetStateAction<string>>;
   setStep: SetterOrUpdater<number>;
-  powerWrite: boolean;
-  setPowerIsWrite: SetterOrUpdater<boolean>;
-  mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
-    unknown,
-    FormData,
-    unknown
-  >;
+  isPowerWrite: boolean;
+  setIsPowerWrite: SetterOrUpdater<boolean>;
 }
 
 interface BasicSubmit {
@@ -44,11 +38,10 @@ const Curriculum = ({
   curInfo,
   setCurInfo,
   setStep,
-  powerWrite,
-  setPowerIsWrite,
-}: // mutate
-Props) => {
-  const isWritten = useSetRecoilState(isWrite);
+  isPowerWrite,
+  setIsPowerWrite,
+}: Props) => {
+  const setIsWritten = useSetRecoilState(isWrite);
   const { mutate, isSuccess, isError } = usePostWrite();
   const screenWidth = useWindowSize();
   const toBack = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -61,8 +54,8 @@ Props) => {
   useEffect(() => {
     if (isSuccess) {
       console.log("성공");
-      setPowerIsWrite(prev => !prev);
-      isWritten(prev => !prev);
+      setIsPowerWrite(prev => !prev);
+      setIsWritten(prev => !prev);
     }
     if (isError) {
       console.log("실패");

--- a/client/components/createModal/ExtraInfo.tsx
+++ b/client/components/createModal/ExtraInfo.tsx
@@ -7,16 +7,16 @@ import { SetterOrUpdater } from "recoil";
 import { Info } from "./WriteModal";
 import { Dispatch } from "react";
 
-interface Additional {
+interface ExtraInfo {
   [index: string]: string | string[];
 }
 
 interface Props {
-  setAddInfo: Dispatch<SetStateAction<Info>>;
+  setExtraInfo: Dispatch<SetStateAction<Info>>;
   setStep: SetterOrUpdater<number>;
 }
 
-const Additional = ({ setAddInfo, setStep }: Props) => {
+const ExtraInfo = ({ setExtraInfo, setStep }: Props) => {
   const [previewImages, setPreviewImages] = useState([]);
   const [detailImage, setDetailImage] = useState<string[]>([]);
   const imageInput: any = useRef();
@@ -24,7 +24,7 @@ const Additional = ({ setAddInfo, setStep }: Props) => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<Additional>({
+  } = useForm<ExtraInfo>({
     mode: "onBlur",
   });
 
@@ -58,9 +58,9 @@ const Additional = ({ setAddInfo, setStep }: Props) => {
   };
 
   /** 제출 코드 **/
-  const testSubmit = (addtionalData: Additional) => {
+  const testSubmit = (addtionalData: ExtraInfo) => {
     addtionalData.detailImage = detailImage;
-    setAddInfo(addtionalData);
+    setExtraInfo(addtionalData);
     setStep(prev => prev + 1);
   };
 
@@ -219,4 +219,4 @@ const Additional = ({ setAddInfo, setStep }: Props) => {
     </>
   );
 };
-export default Additional;
+export default ExtraInfo;

--- a/client/components/createModal/WriteModal.tsx
+++ b/client/components/createModal/WriteModal.tsx
@@ -1,7 +1,7 @@
 import ModalBackDrop from "components/reuse/container/ModalBackDrop";
 import StepNavWrapper from "components/reuse/container/StepNavWrapper";
 import CreateModalContainer from "components/reuse/CreateModalContainer";
-import Additional from "./Additional";
+import ExtraInfo from "./ExtraInfo";
 import BasicInfo from "./BasicInfo";
 import Curriculum from "./Curriculum";
 import { inputStep, powerWriteModal } from "atoms/main/mainAtom";
@@ -18,7 +18,7 @@ export interface Info {
 
 const WriteModal = () => {
   const [basicInfo, setBasicInfo] = useState<Info>({});
-  const [addInfo, setAddInfo] = useState<Info>({});
+  const [extraInfo, setExtraInfo] = useState<Info>({});
   const [curInfo, setCurInfo] = useState("");
   const [step, setStep] = useRecoilState(inputStep);
   const [isPowerWrite, setIsPowerWrite] = useRecoilState(powerWriteModal);
@@ -27,7 +27,7 @@ const WriteModal = () => {
   };
 
   console.log("basic", basicInfo);
-  console.log("add", addInfo);
+  console.log("add", extraInfo);
   console.log("cur", curInfo);
 
   return (
@@ -43,20 +43,15 @@ const WriteModal = () => {
           />
         )}
         {step === 2 && (
-          <Additional
-            // addInfo={addInfo}
-            setAddInfo={setAddInfo}
-            setStep={setStep}
-          />
+          <ExtraInfo setExtraInfo={setExtraInfo} setStep={setStep} />
         )}
         {step === 3 && (
           <Curriculum
             basicInfo={basicInfo}
-            addInfo={addInfo}
+            extraInfo={extraInfo}
             curInfo={curInfo}
             setCurInfo={setCurInfo}
             setStep={setStep}
-            isPowerWrite={isPowerWrite}
             setIsPowerWrite={setIsPowerWrite}
           />
         )}

--- a/client/components/createModal/WriteModal.tsx
+++ b/client/components/createModal/WriteModal.tsx
@@ -7,8 +7,6 @@ import Curriculum from "./Curriculum";
 import { inputStep, powerWriteModal } from "atoms/main/mainAtom";
 import { useRecoilState } from "recoil";
 import { useState } from "react";
-import { AxiosResponse } from "axios";
-import { UseMutateFunction } from "react-query";
 
 interface ObjectPart {
   [index: string]: string | string[];
@@ -18,23 +16,14 @@ export interface Info {
   [index: string]: string | string[] | ObjectPart;
 }
 
-interface Props {
-  mutate: UseMutateFunction<
-    AxiosResponse<any, any>,
-    unknown,
-    FormData,
-    unknown
-  >;
-}
-
-const WriteModal = ({ mutate }: Props) => {
+const WriteModal = () => {
   const [basicInfo, setBasicInfo] = useState<Info>({});
   const [addInfo, setAddInfo] = useState<Info>({});
   const [curInfo, setCurInfo] = useState("");
   const [step, setStep] = useRecoilState(inputStep);
-  const [powerWrite, setPowerIsWrite] = useRecoilState(powerWriteModal);
+  const [isPowerWrite, setIsPowerWrite] = useRecoilState(powerWriteModal);
   const toWrite = () => {
-    setPowerIsWrite(prev => !prev);
+    setIsPowerWrite(prev => !prev);
   };
 
   console.log("basic", basicInfo);
@@ -67,9 +56,8 @@ const WriteModal = ({ mutate }: Props) => {
             curInfo={curInfo}
             setCurInfo={setCurInfo}
             setStep={setStep}
-            powerWrite={powerWrite}
-            setPowerIsWrite={setPowerIsWrite}
-            mutate={mutate}
+            isPowerWrite={isPowerWrite}
+            setIsPowerWrite={setIsPowerWrite}
           />
         )}
       </CreateModalContainer>

--- a/client/components/filter/MobileLanguageFilter.tsx
+++ b/client/components/filter/MobileLanguageFilter.tsx
@@ -30,13 +30,6 @@ const MoblieLanguageFilter = () => {
   };
   return (
     <>
-      {/* 테스트용으로 확인이 끝난뒤에 삭제 예정입니다 */}
-      <button
-        className="w-32 h-9 flex flex-col justify-center items-center cursor-pointer fixed top-48 bg-pointColor z-10 rounded-xl text-white"
-        onClick={handleModalClick}
-      >
-        테스트버튼
-      </button>
       <div
         className={
           modal === 0

--- a/client/hooks/auth/usePostLogin.tsx
+++ b/client/hooks/auth/usePostLogin.tsx
@@ -1,10 +1,11 @@
 import { useMutation } from "react-query";
 import postLogin from "apis/auth/postLogin";
-import { useRecoilState } from "recoil";
-import { loginErrorMessage } from "atoms/auth/authAtom";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { loginErrorMessage, logUser } from "atoms/auth/authAtom";
 
 const usePostLogin = () => {
   const [error, setError] = useRecoilState(loginErrorMessage);
+  const setLog = useSetRecoilState<boolean>(logUser);
 
   return useMutation(postLogin, {
     onSuccess: (res: any) => {
@@ -12,6 +13,7 @@ const usePostLogin = () => {
       localStorage.setItem("refresh_token", res.headers.refreshtoken);
       localStorage.setItem("email", res.data.email);
       localStorage.setItem("name", res.data.name);
+      setLog(prev => !prev);
     },
     onError: (err: any) => {
       setError(err.response.data.message);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
         "react-slick": "^0.29.0",
         "react-toastify": "^9.1.1",
         "recoil": "^0.7.6",
+        "recoil-persist": "^4.2.0",
         "sharp": "^0.31.3",
         "slick-carousel": "^1.8.1",
         "tailwind-scrollbar-hide": "^1.1.7",
@@ -6386,6 +6387,14 @@
         }
       }
     },
+    "node_modules/recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
+      }
+    },
     "node_modules/refractor": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
@@ -12400,6 +12409,12 @@
       "requires": {
         "hamt_plus": "1.0.2"
       }
+    },
+    "recoil-persist": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-4.2.0.tgz",
+      "integrity": "sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==",
+      "requires": {}
     },
     "refractor": {
       "version": "3.6.0",

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,7 @@
     "react-slick": "^0.29.0",
     "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",
+    "recoil-persist": "^4.2.0",
     "sharp": "^0.31.3",
     "slick-carousel": "^1.8.1",
     "tailwind-scrollbar-hide": "^1.1.7",


### PR DESCRIPTION
- [X] main page alert를 띄우기 위해서 props drilling을 `navbar -> writeModal -> curriculum`으로 시도할 예정 
  - [x] 첫렌더링시에만 toast alert방지 이후 글작성 이후 atom이 변경될 때마다 alert 렌더링 
- [x] tablet에서 footer 높이
- [x] 모바일 헤더 공백 부분 수정
- [x] (추가) 로그아웃 이벤트 생성
  - 로그인 정보를 recoil-persist로 영속성으로 전환하여 새로고침으로도 상태 증발 방지
  - 로그아웃 시 localStorage.clear()로 전부 비워주고 로그인 상태를 반전, 이후 toast alert
- [ ] invalidate quries테스트 필요(추후 테스트 후 branch 삭제 예정)