### PR TITLE
refactor : 과외 요약정보 조회 시 토큰값으로 수정 가능한지 비교하는 로직 추가

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/controller/LessonController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/controller/LessonController.java
@@ -13,6 +13,7 @@ import com.codueon.boostUp.domain.lesson.dto.Post.PostSearchLesson;
 import com.codueon.boostUp.domain.lesson.dto.etc.WrapUrl;
 import com.codueon.boostUp.domain.lesson.service.LessonService;
 import com.codueon.boostUp.global.security.token.JwtAuthenticationToken;
+import io.jsonwebtoken.Jwt;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.data.domain.Page;
@@ -189,8 +190,12 @@ public class LessonController {
      * @author mozzi327
      */
     @GetMapping("/{lesson-id}")
-    public ResponseEntity<?> getLesson(@PathVariable("lesson-id") Long lessonId) {
-        GetLesson response = lessonService.getDetailLesson(lessonId);
+    public ResponseEntity<?> getLesson(@PathVariable("lesson-id") Long lessonId,
+                                       Authentication authentication) {
+        JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
+        Long memberId = getMemberIdIfExistToken(token);
+
+        GetLesson response = lessonService.getDetailLesson(lessonId, memberId);
         return ResponseEntity.ok().body(response);
     }
 

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/dto/Get/GetLesson.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/dto/Get/GetLesson.java
@@ -21,6 +21,11 @@ public class GetLesson {
     private Integer career;
     private Integer cost;
     private List<String> address;
+    private Boolean editable;
+
+    public void setEditable(Boolean editable) {
+        this.editable = editable;
+    }
 
     @Builder
     @QueryProjection

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/LessonRepositoryImpl.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/LessonRepositoryImpl.java
@@ -7,6 +7,9 @@ import com.codueon.boostUp.domain.lesson.dto.Get.QGetMainPageLesson;
 import com.codueon.boostUp.domain.lesson.dto.Post.PostSearchLesson;
 import com.codueon.boostUp.domain.lesson.entity.AddressInfo;
 import com.codueon.boostUp.domain.lesson.entity.LanguageInfo;
+import com.codueon.boostUp.domain.lesson.entity.Lesson;
+import com.codueon.boostUp.domain.lesson.service.LessonDbService;
+import com.codueon.boostUp.global.security.token.JwtAuthenticationToken;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
@@ -28,7 +31,6 @@ import static com.codueon.boostUp.domain.member.entity.QMember.member;
 
 
 public class LessonRepositoryImpl implements CustomLessonRepository {
-
     private final JPAQueryFactory queryFactory;
 
     public LessonRepositoryImpl(EntityManager em) {

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
@@ -18,6 +18,7 @@ import com.codueon.boostUp.global.exception.ExceptionCode;
 import com.codueon.boostUp.global.file.AwsS3Service;
 import com.codueon.boostUp.global.file.FileHandler;
 import com.codueon.boostUp.global.file.UploadFile;
+import com.codueon.boostUp.global.security.token.JwtAuthenticationToken;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.data.domain.Page;
@@ -505,9 +506,12 @@ public class LessonService {
      * @return GetLesson
      * @author mozzi327
      */
-    public GetLesson getDetailLesson(Long lessonId) {
+    public GetLesson getDetailLesson(Long lessonId,Long memberId) {
+        GetLesson getLesson = lessonRepository.getDetailLesson(lessonId);
+        getLesson.setEditable(editable(lessonId, memberId));
 
-        return lessonRepository.getDetailLesson(lessonId);
+        return getLesson;
+
     }
 
     /**
@@ -550,5 +554,12 @@ public class LessonService {
         return GetTutorLesson.builder()
                 .lesson(findLesson)
                 .build();
+    }
+
+    private Boolean editable(Long lessonId, Long memberId) {
+        Lesson lesson = lessonDbService.ifExistsReturnLesson(lessonId);
+        if (lesson.getMemberId() == memberId) {
+            return true;
+        } else return false;
     }
 }

--- a/server/src/test/java/com/codueon/boostUp/domain/lesson/controller/LessonGetTest.java
+++ b/server/src/test/java/com/codueon/boostUp/domain/lesson/controller/LessonGetTest.java
@@ -431,7 +431,7 @@ public class LessonGetTest extends LessonControllerTest {
                 .lesson(lesson)
                 .build();
 
-        given(lessonService.getDetailLesson(Mockito.anyLong())).willReturn(getLesson);
+        given(lessonService.getDetailLesson(Mockito.anyLong(), Mockito.anyLong())).willReturn(getLesson);
 
         ResultActions actions =
                 mockMvc.perform(


### PR DESCRIPTION
## 변경사항
- 과외 요악정보 조회 시 토큰값과 현재 memberId를 비교하여 게시물이 수정 가능한지 비교하는 로직 추가 (editable 반환 추가)