### PR TITLE
refactor : 과외 요약 정보 수정시 프로필 이미지 수정 리팩터링

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/dto/Patch/PostLessonInfoEdit.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/dto/Patch/PostLessonInfoEdit.java
@@ -16,6 +16,7 @@ public class PostLessonInfoEdit {
     private Integer career;
     private Integer cost;
     private List<Integer> addresses;
+    private String editState;
 
     @Builder
     public PostLessonInfoEdit(List<Integer> languages,
@@ -24,7 +25,8 @@ public class PostLessonInfoEdit {
                               String company,
                               Integer career,
                               Integer cost,
-                              List<Integer> addresses) {
+                              List<Integer> addresses,
+                              String editState) {
         this.languages = languages;
         this.name = name;
         this.title = title;
@@ -32,5 +34,6 @@ public class PostLessonInfoEdit {
         this.career = career;
         this.cost = cost;
         this.addresses = addresses;
+        this.editState = editState;
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
@@ -217,11 +217,11 @@ public class LessonService {
 
         List<Integer> languageList = postLessonInfoEdit.getLanguages();
         List<Integer> addressList = postLessonInfoEdit.getAddresses();
-
+        String editState = postLessonInfoEdit.getEditState();
         lessonDbService.addLanguageList(languageList, updateLesson);
         lessonDbService.addAddressList(addressList, updateLesson);
 
-        if (!profileImage.isEmpty()) {
+        if (editState == "true") {
             UploadFile uploadFile = fileHandler.uploadFile(profileImage);
             ProfileImage newProfileImage = ProfileImage.builder()
                     .originFileName(uploadFile.getOriginFileName())
@@ -231,8 +231,9 @@ public class LessonService {
                     .build();
 
             updateLesson.addProfileImage(newProfileImage);
+        } else if (editState == "false") {
+            lessonDbService.saveLesson(updateLesson);
         }
-        lessonDbService.saveLesson(updateLesson);
     }
 
     /**
@@ -556,6 +557,12 @@ public class LessonService {
                 .build();
     }
 
+    /**
+     * 등록한 과외가 현재 로그인한 유저의 과외인지 확인하는 메서드
+     * @param lessonId 과외 식별자
+     * @param memberId 회원 식별자
+     * @author Quartz614
+     */
     private Boolean editable(Long lessonId, Long memberId) {
         Lesson lesson = lessonDbService.ifExistsReturnLesson(lessonId);
         if (lesson.getMemberId() == memberId) {


### PR DESCRIPTION
## 변경 사항
- 과외 요약 정보 수정시 프로필 이미지가 수정 되었다면 String true로 받아 새로운 이미지를 저장하고 이미지가 수정 되지 않았다면 false를 받아 원래 이미지를 저장하도록 구현