### PR TITLE
refactor : GetLesson editable 토큰 String null일때 null처리

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/controller/LessonController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/controller/LessonController.java
@@ -192,6 +192,7 @@ public class LessonController {
     @GetMapping("/{lesson-id}")
     public ResponseEntity<?> getLesson(@PathVariable("lesson-id") Long lessonId,
                                        Authentication authentication) {
+
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
         Long memberId = getMemberIdIfExistToken(token);
 

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
@@ -572,8 +572,11 @@ public class LessonService {
      * @author Quartz614
      */
     private Boolean editable(Long lessonId, Long memberId) {
+        if (memberId == null) {
+            return false;
+        }
         Lesson lesson = lessonDbService.ifExistsReturnLesson(lessonId);
-        if (lesson.getMemberId() == memberId) {
+        if (lesson.getMemberId().equals(memberId)) {
             return true;
         } else return false;
     }

--- a/server/src/main/java/com/codueon/boostUp/global/security/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/com/codueon/boostUp/global/security/filter/JwtVerificationFilter.java
@@ -70,6 +70,7 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
      */
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION);
+        if (bearerToken == "null") return null;
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
             return jwtTokenUtils.parseAccessToken(bearerToken);
         }


### PR DESCRIPTION
## 변경 사항
- GetLesson editable 부분 로그아웃 시 데이터 응답이 안되는 오류 해결 (클라이언트에서 보내는 토큰 null과 서버에서 받는 null이 같다는 것을 인식 못한 오류)