### PR TITLE
feat: 종료된 과외 삭제 기능 구현 및 코드 리팩토링

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/CustomLessonRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/CustomLessonRepository.java
@@ -7,18 +7,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomLessonRepository {
-
     Page<GetMainPageLesson> getMainPageLessons(Pageable pageable);
-
     Page<GetMainPageLesson> getMainPageLessonsAndBookmarkInfo(Long memberId, Pageable pageable);
-
     Page<GetMainPageLesson> getMainPageLessonByLanguage(Integer languageId, Pageable pageable);
-
     Page<GetMainPageLesson> getMainPageLessonByLanguageAndBookmarkInfo(Long memberId, Integer languageId, Pageable pageable);
-
     Page<GetMainPageLesson> getDetailSearchMainPageLesson(PostSearchLesson postSearchLesson, Pageable pageable);
-
     Page<GetMainPageLesson> getDetailSearchMainPageLessonAndGetBookmarkInfo(Long memberId, PostSearchLesson postSearchLesson, Pageable pageable);
-
     GetLesson getDetailLesson(Long lessonId);
+    Long getMemberIdByLessonId(Long lessonId);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/LessonRepositoryImpl.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/repository/LessonRepositoryImpl.java
@@ -288,4 +288,20 @@ public class LessonRepositoryImpl implements CustomLessonRepository {
                 ).from(bookmark)
                 .where(bookmark.lessonId.eq(lessonId).and(bookmark.memberId.eq(memberId)));
     }
+
+    /**
+     * 과외 등록한 사용자 식별자 조회 쿼라
+     * @param lessonId 과외 식별자
+     * @return Long
+     * @author LeeGoh
+     */
+    public Long getMemberIdByLessonId(Long lessonId) {
+        Long memberId = queryFactory
+                .select(member.id)
+                .from(member)
+                .leftJoin(lesson).on(member.id.eq(lesson.memberId))
+                .where(lesson.id.eq(lessonId))
+                .fetchOne();
+        return memberId;
+    }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonDbService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonDbService.java
@@ -1,18 +1,18 @@
 package com.codueon.boostUp.domain.lesson.service;
 
 import com.codueon.boostUp.domain.lesson.entity.*;
-import com.codueon.boostUp.domain.lesson.repository.*;
+import com.codueon.boostUp.domain.lesson.repository.CurriculumRepository;
+import com.codueon.boostUp.domain.lesson.repository.LessonInfoRepository;
+import com.codueon.boostUp.domain.lesson.repository.LessonRepository;
 import com.codueon.boostUp.global.exception.BusinessLogicException;
 import com.codueon.boostUp.global.exception.ExceptionCode;
 import com.codueon.boostUp.global.file.AwsS3Service;
 import com.codueon.boostUp.global.file.UploadFile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -176,6 +176,16 @@ public class LessonDbService {
     public Curriculum ifExsistsReturnCurriculum(Long lessonId) {
         return curriculumRepository.findByLessonId(lessonId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.CURRICULUM_NOT_FOUND));
+    }
+
+    /**
+     * 과외 등록한 사용자 식별자 조회 메서드
+     * @param lessonId 과외 식별자
+     * @return Long
+     * @author LeeGoh
+     */
+    public Long getMemberIdByLessonId(Long lessonId) {
+        return lessonRepository.getMemberIdByLessonId(lessonId);
     }
 
     /*--------------------------------------- DB Update 메서드 --------------------------------------*/

--- a/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/lesson/service/LessonService.java
@@ -11,7 +11,7 @@ import com.codueon.boostUp.domain.lesson.entity.*;
 import com.codueon.boostUp.domain.lesson.repository.LessonRepository;
 import com.codueon.boostUp.domain.member.entity.Member;
 import com.codueon.boostUp.domain.member.service.MemberDbService;
-import com.codueon.boostUp.domain.reveiw.service.ReviewService;
+import com.codueon.boostUp.domain.reveiw.service.ReviewDbService;
 import com.codueon.boostUp.domain.suggest.entity.Suggest;
 import com.codueon.boostUp.domain.suggest.service.SuggestDbService;
 import com.codueon.boostUp.global.exception.BusinessLogicException;
@@ -21,7 +21,6 @@ import com.codueon.boostUp.global.file.FileHandler;
 import com.codueon.boostUp.global.file.UploadFile;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.apache.tomcat.jni.File;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.codueon.boostUp.domain.suggest.entity.SuggestStatus.*;
-import static com.codueon.boostUp.global.exception.ExceptionCode.NOT_ACCEPT_SUGGEST;
+import static com.codueon.boostUp.global.exception.ExceptionCode.NOT_PAY_IN_PROGRESS;
 import static com.codueon.boostUp.global.exception.ExceptionCode.NOT_PAY_SUCCESS;
 
 @Service
@@ -43,7 +42,7 @@ public class LessonService {
     private final AwsS3Service awsS3Service;
     private final MemberDbService memberDbService;
     private final SuggestDbService suggestDbService;
-    private final ReviewService reviewService;
+    private final ReviewDbService reviewDbService;
     private final BookmarkRepository bookmarkRepository;
     private final LessonRepository lessonRepository;
 
@@ -388,7 +387,7 @@ public class LessonService {
 
         for (Suggest suggest : findSuggest) {
             if (suggest.getSuggestStatus().equals(ACCEPT_IN_PROGRESS)) {
-                throw new BusinessLogicException(NOT_ACCEPT_SUGGEST);
+                throw new BusinessLogicException(NOT_PAY_IN_PROGRESS);
             } else if (suggest.getSuggestStatus().equals(DURING_LESSON)) {
                 throw new BusinessLogicException(NOT_PAY_SUCCESS);
             } else if (suggest.getSuggestStatus().equals(PAY_IN_PROGRESS)) {
@@ -399,7 +398,7 @@ public class LessonService {
         LessonInfo findLessonInfo = lessonDbService.ifExsitsReturnLessonInfo(lessonId);
         Curriculum findCurriculum = lessonDbService.ifExsistsReturnCurriculum(lessonId);
 
-        reviewService.removeAllByReviews(lessonId);
+        reviewDbService.removeAllByReviews(lessonId);
         bookmarkRepository.deleteByLessonId(lessonId);
         fileHandler.delete(findLesson.getProfileImage().getFilePath());
         findLessonInfo.getCareerImages().forEach(careerImage -> fileHandler.delete(careerImage.getFilePath()));
@@ -427,7 +426,7 @@ public class LessonService {
 
         for (Suggest suggest : findSuggest) {
             if (suggest.getSuggestStatus().equals(ACCEPT_IN_PROGRESS)) {
-                throw new BusinessLogicException(NOT_ACCEPT_SUGGEST);
+                throw new BusinessLogicException(NOT_PAY_IN_PROGRESS);
             } else if (suggest.getSuggestStatus().equals(DURING_LESSON)) {
                 throw new BusinessLogicException(NOT_PAY_SUCCESS);
             } else if (suggest.getSuggestStatus().equals(PAY_IN_PROGRESS)) {
@@ -438,7 +437,7 @@ public class LessonService {
         LessonInfo findLessonInfo = lessonDbService.ifExsitsReturnLessonInfo(lessonId);
         Curriculum findCurriculum = lessonDbService.ifExsistsReturnCurriculum(lessonId);
 
-        reviewService.removeAllByReviews(lessonId);
+        reviewDbService.removeAllByReviews(lessonId);
         bookmarkRepository.deleteByLessonId(lessonId);
 
         String dir = "profileImage";

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/controller/ReviewController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.codueon.boostUp.domain.reveiw.controller;
 
 import com.codueon.boostUp.domain.dto.MultiResponseDto;
 import com.codueon.boostUp.domain.reveiw.dto.*;
+import com.codueon.boostUp.domain.reveiw.service.ReviewDbService;
 import com.codueon.boostUp.domain.reveiw.service.ReviewService;
 import com.codueon.boostUp.global.security.token.JwtAuthenticationToken;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/review")
 public class ReviewController {
     private final ReviewService reviewService;
+    private final ReviewDbService reviewDbService;
 
     /**
      * 사용자 리뷰 생성 컨트롤러 메서드
@@ -33,7 +35,6 @@ public class ReviewController {
                                         Authentication authentication) {
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
         Long memberId = getMemberIdIfExistToken(token);
-
         reviewService.createStudentReview(memberId, lessonId, suggestId, postReview);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
@@ -48,7 +49,7 @@ public class ReviewController {
     @GetMapping("/lesson/{lesson-id}")
     public ResponseEntity<GetAllDetailReviews> getDetailInfoReviews(@PathVariable("lesson-id") Long lessonId,
                                                                     Pageable pageable) {
-        Page<GetReview> getReviews = reviewService.findAllDetailInfoReviews(lessonId, pageable);
+        Page<GetReview> getReviews = reviewDbService.findAllDetailInfoReviews(lessonId, pageable);
         return ResponseEntity.ok().body(new GetAllDetailReviews(getReviews));
     }
 
@@ -64,7 +65,7 @@ public class ReviewController {
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
         Long memberId = getMemberIdIfExistToken(token);
 
-        Page<GetReviewMyPage> getReviews = reviewService.findAllMyPageReviews(memberId, pageable);
+        Page<GetReviewMyPage> getReviews = reviewDbService.findAllMyPageReviews(memberId, pageable);
         return ResponseEntity.ok().body(new MultiResponseDto<>(getReviews));
     }
 
@@ -95,7 +96,6 @@ public class ReviewController {
                                           Authentication authentication) {
         JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
         Long memberId = getMemberIdIfExistToken(token);
-
         reviewService.removeReview(memberId, reviewId);
         return ResponseEntity.noContent().build();
     }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/repository/ReviewRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
     Optional<Review> findByLessonIdAndMemberId(Long lessonId, Long memberId);
     Optional<Review> findByMemberIdAndId(Long memberId, Long reviewId);
+    Optional<Review> findBySuggestId(Long suggestId);
     List<Review> removeAllByLessonId(Long lessonId);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewDbService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewDbService.java
@@ -1,9 +1,99 @@
 package com.codueon.boostUp.domain.reveiw.service;
 
+import com.codueon.boostUp.domain.reveiw.dto.GetReview;
+import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
+import com.codueon.boostUp.domain.reveiw.entity.Review;
+import com.codueon.boostUp.domain.reveiw.repository.ReviewRepository;
+import com.codueon.boostUp.global.exception.BusinessLogicException;
+import com.codueon.boostUp.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewDbService {
+    private final ReviewRepository reviewRepository;
+
+    public Review saveReview(Review review) {
+        return reviewRepository.save(review);
+    }
+
+    /**
+     * 사용자 리뷰 정보 조회 메서드
+     * @param reviewId 리뷰 식별자
+     * @return Review
+     * @author mozzi327
+     */
+    public Review ifExistReturnReview(Long memberId, Long reviewId) {
+        return reviewRepository.findByMemberIdAndId(memberId, reviewId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REVIEW_NOT_FOUND));
+    }
+
+    /**
+     * 사용자 리뷰 정보 조회 메서드2
+     * @param suggestId 신청 식별자
+     * @return Review
+     * @author LeeGoh
+     */
+    public Review findBySuggestIdAndIfExistReturnReview(Long suggestId) {
+        return reviewRepository.findBySuggestId(suggestId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REVIEW_NOT_FOUND));
+    }
+
+    /**
+     * 사용자 리뷰가 이미 작성되어 있는지 확인하는 메서드
+     * @param lessonId 과외 식별자
+     * @param memberId 페이지 정보
+     * @author mozzi327
+     */
+    public void ifExistReviewThrowException(Long lessonId, Long memberId) {
+        if(reviewRepository.findByLessonIdAndMemberId(lessonId, memberId).isPresent())
+            throw new BusinessLogicException(ExceptionCode.REVIEW_ONLY_ONE);
+    }
+
+    /**
+     * 과외 상세페이지 리뷰 전체 조회 메서드
+     * @param lessonId 과외 식별자
+     * @param pageable 페이지 정보
+     * @return Page(GetReview)
+     * @author mozzi327
+     */
+    @Transactional
+    public Page<GetReview> findAllDetailInfoReviews(Long lessonId, Pageable pageable) {
+        return reviewRepository.getReviewList(lessonId, pageable);
+    }
+
+    /**
+     * 사용자 마이페이지 리뷰 전체 조회 메서드
+     * @param memberId 사용자 식별자
+     * @param pageable 페이지 정보
+     * @return Page(GetReviewMyPage)
+     * @author mozzi327
+     */
+    @Transactional
+    public Page<GetReviewMyPage> findAllMyPageReviews(Long memberId, Pageable pageable) {
+        return reviewRepository.getMyPageReviewList(memberId, pageable);
+    }
+
+    /**
+     * 리뷰 삭제 메서드
+     * @param review 리뷰 정보
+     * @author LeeGoh
+     */
+    public void removeReview(Review review) {
+        reviewRepository.delete(review);
+    }
+
+    /**
+     * 리뷰 전체 삭제 메서드
+     * @param lessonId 과외 식별자
+     * @author Quartz614
+     */
+    public void removeAllByReviews(Long lessonId) {
+        reviewRepository.removeAllByLessonId(lessonId);
+    }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/reveiw/service/ReviewService.java
@@ -1,19 +1,12 @@
 package com.codueon.boostUp.domain.reveiw.service;
 
-import com.codueon.boostUp.domain.reveiw.dto.GetReview;
-import com.codueon.boostUp.domain.reveiw.dto.GetReviewMyPage;
 import com.codueon.boostUp.domain.reveiw.dto.PatchReview;
 import com.codueon.boostUp.domain.reveiw.dto.PostReview;
 import com.codueon.boostUp.domain.reveiw.entity.Review;
-import com.codueon.boostUp.domain.reveiw.repository.ReviewRepository;
 import com.codueon.boostUp.domain.suggest.entity.Suggest;
 import com.codueon.boostUp.domain.suggest.service.SuggestDbService;
-import com.codueon.boostUp.global.exception.BusinessLogicException;
-import com.codueon.boostUp.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -22,8 +15,8 @@ import javax.transaction.Transactional;
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
-    private final ReviewRepository reviewRepository;
     private final SuggestDbService suggestDbService;
+    private final ReviewDbService reviewDbService;
 
     /**
      * 사용자 리뷰 작성 메서드
@@ -41,8 +34,7 @@ public class ReviewService {
 //        if(!suggest.getStatus().equals(END_OF_LESSON))
 //            throw new BusinessLogicException(ExceptionCode.NOT_PAY_SUCCESS);
 
-        // 리뷰 내역이 이미 존재할 때 예외 처리
-        ifExistReviewThrowException(lessonId, memberId);
+        reviewDbService.ifExistReviewThrowException(lessonId, memberId);
 
         Review review = Review.builder()
                 .comment(postReview.getComment())
@@ -51,31 +43,7 @@ public class ReviewService {
                 .lessonId(lessonId)
                 .suggestId(suggestId)
                 .build();
-        reviewRepository.save(review);
-    }
-
-    /**
-     * 과외 상세페이지 리뷰 전체 조회 메서드
-     * @param lessonId 과외 식별자
-     * @param pageable 페이지 정보
-     * @return Page(GetReview)
-     * @author mozzi327
-     */
-    @Transactional
-    public Page<GetReview> findAllDetailInfoReviews(Long lessonId, Pageable pageable) {
-        return reviewRepository.getReviewList(lessonId, pageable);
-    }
-
-    /**
-     * 사용자 마이페이지 리뷰 전체 조회 메서드
-     * @param memberId 사용자 식별자
-     * @param pageable 페이지 정보
-     * @return Page(GetReviewMyPage)
-     * @author mozzi327
-     */
-    @Transactional
-    public Page<GetReviewMyPage> findAllMyPageReviews(Long memberId, Pageable pageable) {
-        return reviewRepository.getMyPageReviewList(memberId, pageable);
+        reviewDbService.saveReview(review);
     }
 
     /**
@@ -85,9 +53,9 @@ public class ReviewService {
      * @author mozzi327
      */
     public void editReview(Long memberId, Long reviewId, PatchReview patchReview) {
-        Review findReview = ifExistReturnReview(memberId, reviewId);
+        Review findReview = reviewDbService.ifExistReturnReview(memberId, reviewId);
         findReview.editReview(patchReview);
-        reviewRepository.save(findReview);
+        reviewDbService.saveReview(findReview);
     }
 
     /**
@@ -96,39 +64,17 @@ public class ReviewService {
      * @author mozzi327
      */
     public void removeReview(Long memberId, Long reviewId) {
-        Review findReview = ifExistReturnReview(memberId, reviewId);
-        reviewRepository.delete(findReview);
+        Review findReview = reviewDbService.ifExistReturnReview(memberId, reviewId);
+        reviewDbService.removeReview(findReview);
     }
 
     /**
-     * 리뷰 전체 삭제 메서드
-     *
-     * @param lessonId 과외 식별자
-     * @author Quartz614
+     * 사용자 리뷰 삭제 메서드2
+     * @param suggestId 신청 식별자
+     * @author LeeGoh
      */
-    public void removeAllByReviews(Long lessonId) {
-        reviewRepository.removeAllByLessonId(lessonId);
-    }
-
-    /**
-     * 사용자 리뷰가 이미 작성되어 있는지 확인하는 메서드
-     * @param lessonId 과외 식별자
-     * @param memberId 페이지 정보
-     * @author mozzi327
-     */
-    private void ifExistReviewThrowException(Long lessonId, Long memberId) {
-        if(reviewRepository.findByLessonIdAndMemberId(lessonId, memberId).isPresent())
-            throw new BusinessLogicException(ExceptionCode.REVIEW_ONLY_ONE);
-    }
-
-    /**
-     * 사용자 리뷰 정보 조회 메서드
-     * @param reviewId 리뷰 식별자
-     * @return Review
-     * @author mozzi327
-     */
-    private Review ifExistReturnReview(Long memberId, Long reviewId) {
-        return reviewRepository.findByMemberIdAndId(memberId, reviewId)
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REVIEW_NOT_FOUND));
+    public void removeReviewBySuggestId(Long suggestId) {
+        Review findReview = reviewDbService.findBySuggestIdAndIfExistReturnReview(suggestId);
+        reviewDbService.removeReview(findReview);
     }
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
@@ -367,6 +367,38 @@ public class SuggestController {
     }
 
     /**
+     * 강사 종료 과외 삭제
+     * @param suggestId 신청 식별자
+     * @return ResponseEntity
+     * @author LeeGoh
+     */
+    @DeleteMapping("/suggest/{suggest-id}/tutor")
+    public ResponseEntity deleteTutorEndOfSuggest(@PathVariable("suggest-id") Long suggestId,
+                                                  Authentication authentication) {
+
+        JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
+        Long memberId = getMemberIdIfExistToken(token);
+        suggestService.deleteTutorEndOfSuggest(suggestId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 강사 종료 과외 삭제
+     * @param suggestId 신청 식별자
+     * @return ResponseEntity
+     * @author LeeGoh
+     */
+    @DeleteMapping("/suggest/{suggest-id}/student")
+    public ResponseEntity deleteStudentEndOfSuggest(@PathVariable("suggest-id") Long suggestId,
+                                                  Authentication authentication) {
+
+        JwtAuthenticationToken token = (JwtAuthenticationToken) authentication;
+        Long memberId = getMemberIdIfExistToken(token);
+        suggestService.deleteStudentEndOfSuggest(suggestId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
      * 로그인 확인 메서드
      * @param token 토큰 정보
      * @return Long

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
@@ -383,7 +383,7 @@ public class SuggestController {
     }
 
     /**
-     * 강사 종료 과외 삭제
+     * 학생 종료 과외 삭제
      * @param suggestId 신청 식별자
      * @return ResponseEntity
      * @author LeeGoh

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/repository/SuggestRepository.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/repository/SuggestRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface SuggestRepository extends JpaRepository<Suggest, Long> , CustomSuggestRepository{
     List<Suggest> findAllById(Long lessonId);
-    Optional<Suggest> findByIdAndLessonIdAndMemberId(Long lessonId, Long suggestId, Long memberId);
+    Optional<Suggest> findByIdAndLessonIdAndMemberId(Long suggestId, Long lessonId, Long memberId);
     Optional<Suggest> findByLessonIdAndMemberId(Long lessonId, Long memberId);
     List<Suggest> findAllByLessonIdAndMemberId(Long lessonId, Long memberId);
 }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/service/FeignService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/service/FeignService.java
@@ -1,9 +1,6 @@
 package com.codueon.boostUp.domain.suggest.service;
 
-import com.codueon.boostUp.domain.lesson.entity.Lesson;
-import com.codueon.boostUp.domain.member.entity.Member;
 import com.codueon.boostUp.domain.suggest.entity.PaymentInfo;
-import com.codueon.boostUp.domain.suggest.entity.Suggest;
 import com.codueon.boostUp.domain.suggest.feign.KakaoPayFeignClient;
 import com.codueon.boostUp.domain.suggest.feign.TossPayFeignClient;
 import com.codueon.boostUp.domain.suggest.kakao.*;
@@ -73,25 +70,33 @@ public class FeignService {
     /**
      * Kakao 결제 전 파라미터 입력 메서드
      * @param requestUrl 요청 URL
-     * @param suggest 신청 정보
-     * @param member 사용자 정보
-     * @param lesson 과외 정보
-     * @param paymentInfo 결제 정보
+     * @param suggestId 신청 식별자
+     * @param totalCost 총 가격
+     * @param memberId 사용자 식별자
+     * @param title 과외 타이틀
+     * @param cost 과외 가격
+     * @param quantity 과외 횟수
      * @return ReadyToKakaoPaymentInfo
      * @author LeeGoh
      */
-    public ReadyToKakaoPayInfo setReadyParams(String requestUrl, Suggest suggest, Member member, Lesson lesson, PaymentInfo paymentInfo) {
+    public ReadyToKakaoPayInfo setReadyParams(String requestUrl,
+                                              Long suggestId,
+                                              Integer totalCost,
+                                              Long memberId,
+                                              String title,
+                                              Integer cost,
+                                              Integer quantity) {
         return ReadyToKakaoPayInfo.builder()
                 .cid(cid)
-                .approval_url(requestUrl + paymentProcessUri + "/" + suggest.getId() + "/kakao/success")
-                .cancel_url(requestUrl + paymentProcessUri + "/" + suggest.getId() + "/kakao/cancellation")
-                .fail_url(requestUrl + paymentProcessUri + "/" + suggest.getId() + "/kakao/failure")
-                .partner_order_id(suggest.getId() + "/" + member.getId() + "/" + lesson.getTitle())
-                .partner_user_id(member.getId().toString())
-                .item_name(lesson.getTitle())
-                .quantity(paymentInfo.getQuantity())
-                .total_amount(paymentInfo.getQuantity() * lesson.getCost())
-                .val_amount(suggest.getTotalCost())
+                .approval_url(requestUrl + paymentProcessUri + "/" + suggestId + "/kakao/success")
+                .cancel_url(requestUrl + paymentProcessUri + "/" + suggestId + "/kakao/cancellation")
+                .fail_url(requestUrl + paymentProcessUri + "/" + suggestId + "/kakao/failure")
+                .partner_order_id(suggestId + "/" + memberId + "/" + title)
+                .partner_user_id(memberId.toString())
+                .item_name(title)
+                .quantity(quantity)
+                .total_amount(quantity * cost)
+                .val_amount(totalCost)
                 .tax_free_amount(taxFreeAmount)
                 .build();
     }

--- a/server/src/main/java/com/codueon/boostUp/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/codueon/boostUp/global/exception/ExceptionCode.java
@@ -59,9 +59,14 @@ public enum ExceptionCode {
     ALREADY_EXPIRED_EMAIL_CODE(403, "인증 코드가 만료되었습니다."),
 
 
-    // TODO: 과외 신청 - 결제 관련
-    NOT_ACCEPT_SUGGEST(504, "과외 수락 상태가 아닙니다."),
+    // 과외 신청
+    NOT_ACCEPT_IN_PROGRESS(504, "과외 수락 대기중 상태가 아닙니다."),
+    NOT_PAY_IN_PROGRESS(504, "결제 대기중 상태가 아닙니다."),
     NOT_PAY_SUCCESS(504, "결제 완료 상태가 아닙니다."),
+    NOT_END_OF_LESSON(504, "과외 종료 상태가 아닙니다."),
+    NOT_DURING_LESSON(504, "과외 중 상태가 아닙니다."),
+    NOT_REFUND_PAYMENT(504, "환불 완료 상태가 아닙니다."),
+    NOT_SUGGEST_OR_NOT_ACCEPT(504, "과외 수락 대기중 또는 결제 대기중 상태가 아닙니다."),
 
     // 리뷰 관련
     REVIEW_ONLY_ONE(504, "리뷰는 한 번만 가능합니다."),

--- a/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewControllerTest.java
+++ b/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewControllerTest.java
@@ -4,6 +4,7 @@ import com.codueon.boostUp.domain.lesson.entity.*;
 import com.codueon.boostUp.domain.member.entity.Member;
 import com.codueon.boostUp.domain.reveiw.controller.ReviewController;
 import com.codueon.boostUp.domain.reveiw.entity.Review;
+import com.codueon.boostUp.domain.reveiw.service.ReviewDbService;
 import com.codueon.boostUp.domain.reveiw.service.ReviewService;
 import com.codueon.boostUp.domain.suggest.entity.Suggest;
 import com.codueon.boostUp.domain.suggest.service.SuggestDbService;
@@ -44,6 +45,9 @@ public class ReviewControllerTest {
 
     @MockBean
     protected ReviewService reviewService;
+
+    @MockBean
+    protected ReviewDbService reviewDbService;
 
     @MockBean
     protected SuggestDbService suggestDbService;

--- a/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewGetTest.java
+++ b/server/src/test/java/com/codueon/boostUp/domain/review/controller/ReviewGetTest.java
@@ -50,7 +50,7 @@ public class ReviewGetTest extends ReviewControllerTest {
 
         List<GetReview> reviewList = new ArrayList<>();
         reviewList.add(reviewRes);
-        given(reviewService.findAllDetailInfoReviews(Mockito.anyLong(), Mockito.any(Pageable.class)))
+        given(reviewDbService.findAllDetailInfoReviews(Mockito.anyLong(), Mockito.any(Pageable.class)))
                 .willReturn(new PageImpl<>(reviewList));
 
         ResultActions actions =
@@ -119,7 +119,7 @@ public class ReviewGetTest extends ReviewControllerTest {
         List<GetReviewMyPage> reviewMyPageList = new ArrayList<>();
         reviewMyPageList.add(reviewMyPage);
 
-        given(reviewService.findAllMyPageReviews(Mockito.anyLong(), Mockito.any(Pageable.class)))
+        given(reviewDbService.findAllMyPageReviews(Mockito.anyLong(), Mockito.any(Pageable.class)))
                 .willReturn(new PageImpl<>(reviewMyPageList));
 
         ResultActions actions = mockMvc.perform(


### PR DESCRIPTION
#528 
## 구현 기능
- 강사 종료된 과외 삭제 기능 구현
- 학생 종료된 과외 삭제 기능 구현
- 과외 등록한 사용자의 memberId 조회 메서드 및 쿼리 추가
- ExceptionCode 추가

## 수정 사항
- 예외 처리 수정 및 정리