### PR TITLE
Feat 마이페이지 거절하기 연결 

### DIFF
--- a/client/apis/mypage/postDecline.tsx
+++ b/client/apis/mypage/postDecline.tsx
@@ -1,0 +1,27 @@
+import axios from "axios";
+
+interface Decline {
+  reason: string;
+  suggestId: number;
+}
+
+const postDecline = async ({ reason, suggestId }: Decline) => {
+  const body = {
+    reason: reason,
+  };
+  return await axios.post(
+    `/suggest/${suggestId}/decline
+  `,
+    body,
+    {
+      baseURL: process.env.NEXT_PUBLIC_API_URL,
+      headers: {
+        "content-Type": `application/json`,
+
+        Authorization: `Bearer ${localStorage.getItem("token")}`,
+        // RefreshToken: localStorage.getItem("refresh_token"),
+      },
+    },
+  );
+};
+export default postDecline;

--- a/client/components/Mypage/AcceptModal.tsx
+++ b/client/components/Mypage/AcceptModal.tsx
@@ -37,7 +37,6 @@ const AcceptModal = ({
       quantity: e.quantity,
       suggestId: suggestId,
     };
-    console.log(acceptData);
     mutate(acceptData);
   };
 

--- a/client/components/Mypage/ApplicationList.tsx
+++ b/client/components/Mypage/ApplicationList.tsx
@@ -79,7 +79,10 @@ const ApplicationList = () => {
             <div className="flex flex-col" key={apply.lessonId}>
               <div className="flex flex-row w-full h-fit border border-borderColor rounded-xl desktop:mt-5 tablet:mt-3 mt-2 p-3 pl-5">
                 <div className="flex flex-col w-[60%]">
-                  <div className="mb-3">{apply.name}</div>
+                  <div className="flex mb-2">
+                    <div className="mr-3">신청학생</div>
+                    <div> {apply.name}</div>
+                  </div>
                   <div className="flex mb-2">
                     <div className="mr-3">희망요일</div>
                     <div> {apply.days}</div>

--- a/client/components/Mypage/ApplicationList.tsx
+++ b/client/components/Mypage/ApplicationList.tsx
@@ -73,18 +73,18 @@ const ApplicationList = () => {
         </div>
       ) : null}
       {/* {map} 수업신청정보 */}
-   
+
       {tutorInfoSuccess
         ? applyInfoData?.data.data.map((apply: any) => (
             <div className="flex flex-col" key={apply.lessonId}>
               <div className="flex flex-row w-full h-fit border border-borderColor rounded-xl desktop:mt-5 tablet:mt-3 mt-2 p-3 pl-5">
                 <div className="flex flex-col w-[60%]">
-                  <div className="mb-3 ">{apply.name}</div>
-                  <div className="flex">
+                  <div className="mb-3">{apply.name}</div>
+                  <div className="flex mb-2">
                     <div className="mr-3">희망요일</div>
                     <div> {apply.days}</div>
                   </div>
-                  <div className="flex">
+                  <div className="flex mb-2">
                     <div className="mr-3">희망언어</div>
                     <div> {apply.languages}</div>
                   </div>
@@ -100,11 +100,11 @@ const ApplicationList = () => {
                   </div>
                   {apply.status === "결제 대기 중" ? (
                     <>
-                      <button className="text text-pointColor mt-1">
+                      <button className="text text-pointColor mt-4">
                         채팅하기
                       </button>
                       <button
-                        className="text text-negativeMessage mt-1"
+                        className="text text-negativeMessage mt-4"
                         onClick={openDeclineModal}
                       >
                         거절하기
@@ -113,16 +113,16 @@ const ApplicationList = () => {
                   ) : (
                     <>
                       <button
-                        className="text text-pointColor mt-1"
+                        className="text text-pointColor mt-2"
                         onClick={e => onClickAcceptModal(apply.suggestId)}
                       >
                         수락하기
                       </button>
-                      <button className="text text-pointColor mt-1">
+                      <button className="text text-pointColor mt-2">
                         채팅하기
                       </button>
                       <button
-                        className="text text-negativeMessage mt-1"
+                        className="text text-negativeMessage mt-2"
                         onClick={openDeclineModal}
                       >
                         거절하기

--- a/client/components/Mypage/ApplicationList.tsx
+++ b/client/components/Mypage/ApplicationList.tsx
@@ -48,6 +48,7 @@ const ApplicationList = () => {
   };
 
   const [suggestId, setSuggestId] = useState(0);
+
   const onClickAcceptModal = useCallback(
     (suggestId: number) => {
       setSuggestId(suggestId);
@@ -55,10 +56,18 @@ const ApplicationList = () => {
     },
     [openAccept],
   );
-  const openDeclineModal = () => {
-    setOpenDecline(prev => !prev);
-  };
 
+  const openDeclineModal = useCallback(
+    (suggestId: number) => {
+      setSuggestId(suggestId);
+      setOpenDecline(!openDecline);
+    },
+    [openDecline],
+  );
+
+  const toChat = () => {
+    router.push("/chat/0");
+  };
   return (
     <div className="flex flex-col w-full min-h-[300px] bg-bgColor">
       <button
@@ -76,7 +85,7 @@ const ApplicationList = () => {
 
       {tutorInfoSuccess
         ? applyInfoData?.data.data.map((apply: any) => (
-            <div className="flex flex-col" key={apply.lessonId}>
+            <div className="flex flex-col" key={apply.name}>
               <div className="flex flex-row w-full h-fit border border-borderColor rounded-xl desktop:mt-5 tablet:mt-3 mt-2 p-3 pl-5">
                 <div className="flex flex-col w-[60%]">
                   <div className="flex mb-2">
@@ -98,17 +107,20 @@ const ApplicationList = () => {
                 </div>
 
                 <div className="flex flex-col w-[60%] justify-center items-end">
-                  <div className="text text-textColor font-SCDream6 mt-2">
+                  <div className="text text-textColor font-SCDream6 mb-2">
                     {apply.status}
                   </div>
                   {apply.status === "결제 대기 중" ? (
                     <>
-                      <button className="text text-pointColor mt-4">
+                      <button
+                        className="text text-pointColor mt-4"
+                        onClick={toChat}
+                      >
                         채팅하기
                       </button>
                       <button
                         className="text text-negativeMessage mt-4"
-                        onClick={openDeclineModal}
+                        onClick={e => openDeclineModal(apply.suggestId)}
                       >
                         거절하기
                       </button>
@@ -116,17 +128,20 @@ const ApplicationList = () => {
                   ) : (
                     <>
                       <button
-                        className="text text-pointColor mt-2"
+                        className="text text-pointColor mb-2"
                         onClick={e => onClickAcceptModal(apply.suggestId)}
                       >
                         수락하기
                       </button>
-                      <button className="text text-pointColor mt-2">
+                      <button
+                        className="text text-pointColor mb-2"
+                        onClick={toChat}
+                      >
                         채팅하기
                       </button>
                       <button
-                        className="text text-negativeMessage mt-2"
-                        onClick={openDeclineModal}
+                        className="text text-negativeMessage mb-1"
+                        onClick={e => openDeclineModal(apply.suggestId)}
                       >
                         거절하기
                       </button>
@@ -146,9 +161,9 @@ const ApplicationList = () => {
 
       {openDecline && (
         <DeclineModal
-          onClickToggleModal={onClickAcceptModal}
+          onClickToggleModal={openDeclineModal}
           suggestId={suggestId}
-          openDeclineModal={openDeclineModal}
+          // openDeclineModal={openDeclineModal}
         ></DeclineModal>
       )}
     </div>

--- a/client/components/Mypage/ClassList.tsx
+++ b/client/components/Mypage/ClassList.tsx
@@ -3,6 +3,7 @@ import useGetMyTutor from "hooks/mypage/useGetMyTutor";
 import useGetCloseClass from "hooks/mypage/useGetCloseClass";
 import { useState, useEffect } from "react";
 import Swal from "sweetalert2";
+import { useRouter } from "next/router";
 const ClassList = () => {
   const [aSuggestId, setASuggestId] = useState(0);
 
@@ -53,6 +54,10 @@ const ClassList = () => {
     }
   }, [isSuccess, isError]);
 
+  const router = useRouter();
+  const toChat = () => {
+    router.push("/chat/0");
+  };
   return (
     <>
       <div className="flex flex-col w-full min-h-[300px] bg-bgColor">
@@ -90,7 +95,9 @@ const ClassList = () => {
                 <div className="text text-textColor mb-1 mr-2">
                   {curStu.startTime?.slice(0, 10)}
                 </div>
-                <button className="text text-pointColor mr-2">채팅하기</button>
+                <button className="text text-pointColor mr-2" onClick={toChat}>
+                  채팅하기
+                </button>
                 <button
                   className="text text-negativeMessage mt-2 mr-2"
                   onClick={() => {

--- a/client/components/Mypage/ClassList.tsx
+++ b/client/components/Mypage/ClassList.tsx
@@ -66,7 +66,10 @@ const ClassList = () => {
           {tutorInfoData?.data.data.map((curStu: any) => (
             <div className="flex flex-row w-full h-fit border border-borderColor rounded-xl mt-3 p-3 pl-5">
               <div className="flex flex-col w-[60%]">
-                <div className="mb-3 ">{curStu.name}</div>
+                <div className="flex mb-2">
+                  <div className="mr-3">신청학생</div>
+                  <div> {curStu.name}</div>
+                </div>
                 <div className="flex">
                   <div className="mr-3 mb-2">희망요일</div>
                   <div>{curStu.days}</div>
@@ -81,15 +84,15 @@ const ClassList = () => {
                 </div>
               </div>
               <div className="flex flex-col w-[60%] justify-end items-end">
-                <div className="text text-textColor font-SCDream6 mt-2">
+                <div className="text text-textColor font-SCDream6 mb-1 mr-2">
                   {curStu.status}
                 </div>
-                <div className="text text-textColor">
+                <div className="text text-textColor mb-1 mr-2">
                   {curStu.startTime?.slice(0, 10)}
                 </div>
-                <button className="text text-pointColor m-2">채팅하기</button>
+                <button className="text text-pointColor mr-2">채팅하기</button>
                 <button
-                  className="text text-negativeMessage m-2"
+                  className="text text-negativeMessage mt-2 mr-2"
                   onClick={() => {
                     closeClass(curStu.suggestId);
                   }}

--- a/client/components/Mypage/ClassList.tsx
+++ b/client/components/Mypage/ClassList.tsx
@@ -68,11 +68,11 @@ const ClassList = () => {
               <div className="flex flex-col w-[60%]">
                 <div className="mb-3 ">{curStu.name}</div>
                 <div className="flex">
-                  <div className="mr-3">희망요일</div>
+                  <div className="mr-3 mb-2">희망요일</div>
                   <div>{curStu.days}</div>
                 </div>
                 <div className="flex">
-                  <div className="mr-3">희망언어</div>
+                  <div className="mr-3 mb-2">희망언어</div>
                   <div> {curStu.languages}</div>
                 </div>
                 <div className="flex">
@@ -86,7 +86,6 @@ const ClassList = () => {
                 </div>
                 <div className="text text-textColor">
                   {curStu.startTime?.slice(0, 10)}
-                  {curStu.startTime?.slice(11, 19)}
                 </div>
                 <button className="text text-pointColor m-2">채팅하기</button>
                 <button

--- a/client/components/Mypage/DeclineModal.tsx
+++ b/client/components/Mypage/DeclineModal.tsx
@@ -1,48 +1,64 @@
 import CreateModalContainer from "../reuse/container/CreateModalContainer";
 import { useForm } from "react-hook-form";
 import SmallBtn from "../reuse/btn/SmallBtn";
-import usePostAccept from "hooks/mypage/usePostAccept";
+import usePostDecline from "hooks/mypage/usePostDecline";
 import { useState, useEffect } from "react";
 import Swal from "sweetalert2";
 import { PropsWithChildren } from "react";
-import { useRouter } from "next/router";
-interface Accept {
-  decline: string;
+
+interface Decline {
+  reason: string;
   suggestId: any;
 }
 
 interface ModalDefaultType {
   onClickToggleModal: (suggestId: number) => void;
   suggestId: number;
-  openDeclineModal: () => void;
 }
 
 const DeclineModal = ({
   onClickToggleModal,
   suggestId,
-  openDeclineModal,
 }: PropsWithChildren<ModalDefaultType>) => {
   const {
     control,
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<Accept>({ mode: "onBlur" });
+  } = useForm<Decline>({ mode: "onBlur" });
   //SuggestId 입력필요
+  const { mutate, isSuccess, isError } = usePostDecline();
 
-  const onSubmit = (e: Accept) => {
-    const acceptData = {
-      decline: e.decline,
+  const onSubmit = (e: Decline) => {
+    const declineData = {
+      reason: e.reason,
       suggestId: suggestId,
     };
+    console.log(declineData);
+    mutate(declineData);
   };
+  useEffect(() => {
+    if (isSuccess) {
+      Swal.fire({
+        text: "거절이 완료되었습니다",
+        icon: "success",
+        confirmButtonColor: "#3085d6",
+      });
+      onClickToggleModal(suggestId);
+    }
+
+    if (isError) {
+      Swal.fire({
+        text: "다시 입력해주세요",
+        icon: "warning",
+        confirmButtonColor: "#3085d6",
+      });
+    }
+  }, [isSuccess, isError]);
 
   return (
     <>
-      <div
-        className="fixed z-10 top-0 left-0 bottom-0 right-0 bg-modalBgColor grid place-items-center"
-        onClick={openDeclineModal}
-      >
+      <div className="fixed z-10 top-0 left-0 bottom-0 right-0 bg-modalBgColor grid place-items-center">
         <CreateModalContainer>
           <form
             className="flex flex-col items-center w-full text-sm z-20"
@@ -57,15 +73,15 @@ const DeclineModal = ({
             </div>
             <input
               type="text"
-              placeholder="거절 사유를 입력하세요"
+              placeholder="거절 사유 ex.시간 재조정 필요, 수업언어 불일치 등등"
               className="w-11/12 desktop:w-4/6 h-fit p-2 border border-borderColor outline-pointColor rounded-xl font-SCDream4 text-xs text-textColor tablet:text-sm "
-              {...register("decline", { required: "필수 정보입니다." })}
+              {...register("reason", { required: "필수 정보입니다." })}
             />
             <p className="w-11/12 text-xs text-negativeMessage ml-2 mt-1 tablet:text-sm desktop:w-4/6">
-              {errors?.decline && <span>필수 정보입니다</span>}
+              {errors?.reason && <span>필수 정보입니다</span>}
             </p>
             <div className="flex flex-row justify-center items-center w-full h-fit mt-10">
-              <SmallBtn css="mr-4" onClick={openDeclineModal}>
+              <SmallBtn css="mr-4" onClick={e => onClickToggleModal(suggestId)}>
                 취 소
               </SmallBtn>
               <SmallBtn>거 절</SmallBtn>

--- a/client/components/Mypage/FinishedTutor.tsx
+++ b/client/components/Mypage/FinishedTutor.tsx
@@ -46,11 +46,11 @@ const FinishedTutor = () => {
               <div className="flex flex-col w-[60%]">
                 <div className="mb-3 ">{finished.name}</div>
                 <div className="flex">
-                  <div className="mr-3">희망요일</div>
+                  <div className="mr-3 mb-2">희망요일</div>
                   <div> {finished.days}</div>
                 </div>
                 <div className="flex">
-                  <div className="mr-3">희망언어</div>
+                  <div className="mr-3 mb-2">희망언어</div>
                   <div> {finished.languages}</div>
                 </div>
                 <div className="flex">
@@ -62,7 +62,7 @@ const FinishedTutor = () => {
                 <div className="text text-textColor font-SCDream6 m-2">
                   {finished.status}
                 </div>
-                <div className="text text-textColor">
+                <div className="text text-textColor my-2">
                   {finished.endTime?.slice(0, 10)}
                 </div>
                 <button

--- a/client/components/Mypage/FinishedTutor.tsx
+++ b/client/components/Mypage/FinishedTutor.tsx
@@ -44,7 +44,10 @@ const FinishedTutor = () => {
           {finishedClassData?.data.data.map((finished: any) => (
             <div className="flex flex-row w-full h-fit border border-borderColor rounded-xl mt-3 p-3 pl-5">
               <div className="flex flex-col w-[60%]">
-                <div className="mb-3 ">{finished.name}</div>
+                <div className="flex">
+                  <div className="mr-3 mb-2">신청학생</div>
+                  <div> {finished.name}</div>
+                </div>
                 <div className="flex">
                   <div className="mr-3 mb-2">희망요일</div>
                   <div> {finished.days}</div>
@@ -62,7 +65,7 @@ const FinishedTutor = () => {
                 <div className="text text-textColor font-SCDream6 m-2">
                   {finished.status}
                 </div>
-                <div className="text text-textColor my-2">
+                <div className="text text-textColor my-2 mr-2">
                   {finished.endTime?.slice(0, 10)}
                 </div>
                 <button

--- a/client/components/Mypage/StudentBookmark.tsx
+++ b/client/components/Mypage/StudentBookmark.tsx
@@ -83,7 +83,7 @@ const StudentBookmark = () => {
                     return (
                       <div
                         key={idx}
-                        className={`flex justify-center bg-${el} items-center px-1 py-0.5 ml-1 mt-1 border rounded-xl desktop:text-xs tablet:text-[10px] text-[6px]`}
+                        className={`flex justify-center bg-${el} text-white items-center px-1 py-0.5 ml-1 mt-1 border rounded-xl desktop:text-xs tablet:text-[10px] text-[6px]`}
                       >
                         {el}
                       </div>

--- a/client/components/Mypage/StudentReview.tsx
+++ b/client/components/Mypage/StudentReview.tsx
@@ -12,6 +12,7 @@ import Swal from "sweetalert2";
 import ReviewEditModal from "./ReviewEditModal";
 import { useRecoilState } from "recoil";
 import { powerEditReviewModal, reviewCommentState } from "atoms/main/mainAtom";
+import { useRouter } from "next/router";
 
 const StudentReview = () => {
   const { data: MyReview } = useGetMyReview();
@@ -43,6 +44,10 @@ const StudentReview = () => {
   const handleClickEdit = (comment: string) => {
     setPowerModal(true);
     setCommentState(comment);
+  };
+  const router = useRouter();
+  const toClass = (lessonId: number) => {
+    router.push(`/lesson/${lessonId}`);
   };
 
   return (
@@ -77,7 +82,10 @@ const StudentReview = () => {
                 <div className="flex justify-start items-start w-full h-fit font-SCDream5 desktop:text-xs tablet:text-[12px] text-[8px] text-textColor px-1 py-0.5 ml-1 mt-1">
                   {review.name}
                 </div>
-                <div className="flex justify-start items-start w-full h-fit font-SCDream6 desktop:text-lg tablet:text-base text-xs text-textColor px-1 py-0.5 ml-1 mt-1 flex-wrap">
+                <div
+                  className="flex justify-start items-start w-full h-fit font-SCDream6 desktop:text-lg tablet:text-base text-xs text-textColor px-1 py-0.5 ml-1 mt-1 flex-wrap cursor-pointer"
+                  onClick={() => toClass(review.lessonId)}
+                >
                   {review.title}
                 </div>
                 <div className="flex desktop:text-base tablet:text-sm text-[12px] font-SCDream3 px-1 py-0.5 ml-1 mt-1">

--- a/client/hooks/mypage/usePostDecline.tsx
+++ b/client/hooks/mypage/usePostDecline.tsx
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import postDecline from "apis/mypage/postDecline";
+
+const usePostDecline = () => {
+  return useMutation(postDecline, {
+    onSuccess: (res: any) => {
+      console.log(res);
+    },
+    onError: (err: any) => {
+      console.log(err);
+    },
+  });
+};
+
+export default usePostDecline;


### PR DESCRIPTION
신청학생 항목에 대한 이름을 명시해 선생님 측에서 해당 항목의 의미를 알 수 있게 했습니다.

전체적인 선생님탭, 학생탭의 CSS에서 통일성이 생기도록 일부를 수정했습니다.

선생님 측에서 수락 대기중인 학생에게 거절 이유를 보내며 신청을 거절할 수 있도록 거절 하기 버튼의 기능을 추가했습니다. 
(결제 대기 중인 학생도 가능하도록 이후 조치 필요)