### PR TITLE
refactor: 과외 결제 대기 시 신청 거절 가능하도록 예외 처리 추가

### DIFF
--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/contoller/SuggestController.java
@@ -52,8 +52,8 @@ public class SuggestController {
      */
     @PostMapping("/suggest/{suggest-id}/accept")
     public ResponseEntity<?> acceptSuggest(@PathVariable("suggest-id") Long suggestId,
-                                        @RequestBody @Valid PostPaymentUrl post,
-                                        Authentication authentication) {
+                                           @RequestBody @Valid PostPaymentUrl post,
+                                           Authentication authentication) {
         suggestService.acceptSuggest(suggestId, AuthVO.of(authentication), post.getQuantity());
         return ResponseEntity.ok().build();
     }
@@ -68,8 +68,8 @@ public class SuggestController {
      */
     @PostMapping("/suggest/{suggest-id}/decline")
     public ResponseEntity<?> declineSuggest(@PathVariable("suggest-id") Long suggestId,
-                                         @RequestBody @Valid PostReason postReason,
-                                         Authentication authentication) {
+                                            @RequestBody @Valid PostReason postReason,
+                                            Authentication authentication) {
         suggestService.declineSuggest(suggestId, AuthVO.of(authentication), postReason);
         return ResponseEntity.noContent().build();
     }
@@ -84,7 +84,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/payment/info")
     public ResponseEntity<GetPaymentInfo> getPaymentInfo(@PathVariable("suggest-id") Long suggestId,
-                                         Authentication authentication) {
+                                                         Authentication authentication) {
         return ResponseEntity.ok(suggestDbService.getPaymentInfoOnMyPage(suggestId, AuthVO.ofMemberId(authentication)));
     }
 
@@ -97,7 +97,6 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/kakao/payment")
     public ResponseEntity<Message<?>> orderKakaoPayment(@PathVariable("suggest-id") Long suggestId) {
-
         Message<?> message = suggestService.getKaKapPayUrl(suggestId);
         if (message.getData() == null) suggestService.getFailedPayMessage();
         return ResponseEntity.ok().body(message);
@@ -113,7 +112,6 @@ public class SuggestController {
     @GetMapping("/suggest/{suggest-id}/toss/payment/{payment-id}")
     public ResponseEntity<Message<?>> orderTossPayment(@PathVariable("suggest-id") Long suggestId,
                                                        @PathVariable("payment-id") int paymentId) {
-
         Message<?> message = suggestService.getTossPayUrl(suggestId, paymentId);
         if (message.getData() == null) suggestService.getFailedPayMessage();
         return ResponseEntity.ok().body(message);
@@ -196,7 +194,7 @@ public class SuggestController {
      */
     @GetMapping("suggest/{suggest-id}/payment/check")
     public ResponseEntity<WrapPaymentStatusCheck> paymentStatusCheck(@PathVariable("suggest-id") Long suggestId,
-                                             Authentication authentication) {
+                                                                     Authentication authentication) {
         Boolean paymentCheck = suggestService.getPaymentStatusCheck(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.ok().body(new WrapPaymentStatusCheck(paymentCheck));
     }
@@ -211,7 +209,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/done")
     public ResponseEntity<?> endOfLesson(@PathVariable("suggest-id") Long suggestId,
-                                      Authentication authentication) {
+                                         Authentication authentication) {
         suggestService.setSuggestStatusAndEndTime(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.ok().build();
     }
@@ -226,7 +224,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/refund")
     public ResponseEntity<?> refundPayment(@PathVariable("suggest-id") Long suggestId,
-                                                 Authentication authentication) {
+                                           Authentication authentication) {
         Message message = suggestService.refundPaymentKakaoOrToss(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.ok().body(message);
     }
@@ -241,7 +239,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/refund/info")
     public ResponseEntity<GetRefundPayment> getRefundPaymentInfo(@PathVariable("suggest-id") Long suggestId,
-                                               Authentication authentication) {
+                                                                 Authentication authentication) {
         return ResponseEntity.ok().body(suggestService.getRefundPaymentInfo(suggestId, AuthVO.ofMemberId(authentication)));
     }
 
@@ -254,7 +252,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/attendance")
     public ResponseEntity<GetLessonAttendance> getLessonAttendance(@PathVariable("suggest-id") Long suggestId,
-                                              Authentication authentication) {
+                                                                   Authentication authentication) {
         return ResponseEntity.ok(suggestService.getLessonAttendance(suggestId, AuthVO.ofMemberId(authentication)));
     }
 
@@ -267,7 +265,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/attendance/check")
     public ResponseEntity<WrapQuantityCount> lessonAttendanceCheck(@PathVariable("suggest-id") Long suggestId,
-                                                Authentication authentication) {
+                                                                   Authentication authentication) {
         Integer quantityCount = suggestService.teacherChecksAttendance(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.ok().body(new WrapQuantityCount(quantityCount));
     }
@@ -281,7 +279,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/attendance/cancel")
     public ResponseEntity<WrapQuantityCount> lessonAttendanceCancel(@PathVariable("suggest-id") Long suggestId,
-                                                 Authentication authentication) {
+                                                                    Authentication authentication) {
         Integer quantityCount = suggestService.teacherCancelAttendance(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.ok().body(new WrapQuantityCount(quantityCount));
     }
@@ -296,7 +294,7 @@ public class SuggestController {
      */
     @GetMapping("/suggest/{suggest-id}/receipt")
     public ResponseEntity<GetPaymentReceipt> getPaymentReceipt(@PathVariable("suggest-id") Long suggestId,
-                                            Authentication authentication) {
+                                                               Authentication authentication) {
         return ResponseEntity.ok(suggestDbService.getPaymentReceiptOnMyPage(suggestId, AuthVO.ofMemberId(authentication)));
     }
 
@@ -344,7 +342,7 @@ public class SuggestController {
      */
     @DeleteMapping("/suggest/{suggest-id}")
     public ResponseEntity<?> cancelSuggest(@PathVariable("suggest-id") Long suggestId,
-                                        Authentication authentication) {
+                                           Authentication authentication) {
         suggestService.cancelSuggest(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.noContent().build();
     }
@@ -359,7 +357,7 @@ public class SuggestController {
      */
     @DeleteMapping("/suggest/{suggest-id}/tutor")
     public ResponseEntity<?> deleteTutorEndOfSuggest(@PathVariable("suggest-id") Long suggestId,
-                                                  Authentication authentication) {
+                                                     Authentication authentication) {
         suggestService.deleteTutorEndOfSuggest(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.noContent().build();
     }
@@ -374,7 +372,7 @@ public class SuggestController {
      */
     @DeleteMapping("/suggest/{suggest-id}/student")
     public ResponseEntity<?> deleteStudentEndOfSuggest(@PathVariable("suggest-id") Long suggestId,
-                                                    Authentication authentication) {
+                                                       Authentication authentication) {
         suggestService.deleteStudentEndOfSuggest(suggestId, AuthVO.ofMemberId(authentication));
         return ResponseEntity.noContent().build();
     }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
@@ -51,7 +51,6 @@ public class SuggestService {
      */
     @Transactional
     public void createSuggest(PostSuggest post, Long lessonId, AuthVO authInfo) {
-
 //        if(memberId.equals(lessonDbService.getMemberIdByLessonId(lessonId)) {
 //            throw new BusinessLogicException(ExceptionCode.TUTOR_CANNOT_RESERVATION);
 //        }

--- a/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
+++ b/server/src/main/java/com/codueon/boostUp/domain/suggest/service/SuggestService.java
@@ -51,11 +51,12 @@ public class SuggestService {
      */
     @Transactional
     public void createSuggest(PostSuggest post, Long lessonId, AuthVO authInfo) {
+
 //        if(memberId.equals(lessonDbService.getMemberIdByLessonId(lessonId)) {
 //            throw new BusinessLogicException(ExceptionCode.TUTOR_CANNOT_RESERVATION);
 //        }
-        Lesson findLesson = lessonDbService.ifExistsReturnLesson(lessonId);
 
+        Lesson findLesson = lessonDbService.ifExistsReturnLesson(lessonId);
         suggestDbService.ifUnfinishedSuggestExistsReturnException(lessonId, authInfo.getMemberId());
 
         Suggest suggest = Suggest.builder()
@@ -135,8 +136,9 @@ public class SuggestService {
         if (!authInfo.equals(lessonDbService.getMemberIdByLessonId(findSuggest.getLessonId())))
             throw new BusinessLogicException(INVALID_ACCESS);
 
-        if (!findSuggest.getSuggestStatus().equals(ACCEPT_IN_PROGRESS))
-            throw new BusinessLogicException(NOT_ACCEPT_IN_PROGRESS);
+        if (!findSuggest.getSuggestStatus().equals(ACCEPT_IN_PROGRESS) &&
+            !findSuggest.getSuggestStatus().equals(PAY_IN_PROGRESS))
+            throw new BusinessLogicException(NOT_SUGGEST_OR_NOT_ACCEPT);
 
         Reason reason = Reason.builder().reason(postReason.getReason()).build();
         suggestDbService.saveReason(reason);


### PR DESCRIPTION
## 수정 사항
- 과외 결제 대기 시 신청 거절 가능하도록 예외 처리 추가
```
if (!findSuggest.getSuggestStatus().equals(ACCEPT_IN_PROGRESS) &&
            !findSuggest.getSuggestStatus().equals(PAY_IN_PROGRESS))
            throw new BusinessLogicException(NOT_SUGGEST_OR_NOT_ACCEPT);
```