### PR TITLE
Refactor/things#567 사이트 리펙토링

### DIFF
--- a/client/apis/auth/deleteLogout.tsx
+++ b/client/apis/auth/deleteLogout.tsx
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+export const deleteLogout = async () => {
+  const url = "/member/logout";
+
+  return await axios.delete(url, {
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    headers: {
+      "content-Type": `application/json`,
+      Authorization: `Bearer ${localStorage.getItem("token")}`,
+      RefreshToken: "delete",
+    },
+  });
+};
+
+export default deleteLogout;

--- a/client/atoms/auth/authAtom.tsx
+++ b/client/atoms/auth/authAtom.tsx
@@ -23,7 +23,7 @@ const resetPwStep = atom<Number>({
   default: 1,
 });
 
-const logUser = atom({
+const logUser = atom<boolean>({
   key: "logUser",
   default: false,
   effects_UNSTABLE: [persistAtom],

--- a/client/components/Header/Header.tsx
+++ b/client/components/Header/Header.tsx
@@ -15,6 +15,9 @@ import { useEffect } from "react";
 import { useRouter } from "next/router";
 import usePostSearch from "hooks/main/usePostSearch";
 
+import { useQueryClient } from "@tanstack/react-query";
+import useDeleteLogout from "hooks/auth/useDeleteLogout";
+
 interface SelectData {
   key: number;
   label: string;
@@ -31,6 +34,7 @@ interface SearchData {
 }
 
 const Header = () => {
+  const queryClient = useQueryClient();
   const router = useRouter();
   const [log, setLog] = useRecoilState<boolean>(logUser);
   const [wordOne, setWordOne] = useState<string>("");
@@ -42,6 +46,7 @@ const Header = () => {
   const setMainCardInfo = useSetRecoilState(mainCardInfo);
 
   const { mutate, isSuccess, data } = usePostSearch();
+  const { mutate: mutateLogout } = useDeleteLogout();
 
   useEffect(() => {
     if (log) {
@@ -105,13 +110,7 @@ const Header = () => {
 
   const logInNOutEvent = () => {
     if (log) {
-      localStorage.clear();
-      setLog(prev => !prev);
-      toast.success("로그아웃이 되었습니다", {
-        autoClose: 1500,
-        position: toast.POSITION.TOP_RIGHT,
-      });
-      router.push("/");
+      mutateLogout();
     }
     if (!log) {
       router.push("/login");

--- a/client/components/Maincard/Card.tsx
+++ b/client/components/Maincard/Card.tsx
@@ -82,7 +82,8 @@ const Card = () => {
     <QueryClientProvider client={client}>
       <div className="flex flex-row flex-wrap w-full">
         {cards?.slice(offset, offset + limit).map((card: any) => (
-          <div
+          <Link
+            href={`/lesson/${card.lessonId}`}
             key={card.lessonId}
             className="h-fit m-1 desktop:w-[24%] tablet:w-[32%] w-[47%] rounded-lg"
           >
@@ -103,15 +104,15 @@ const Card = () => {
                   </button>
                 </div>
               </div>
-              <Link href={`/lesson/${card.lessonId}`}>
-                <div className="flex flex-col w-full h-2/3">
+              <div>
+                <div className="flex flex-col w-full h-2/3 bg-white rounded-xl">
                   <div className="flex flex-row whitespace-wrap">
                     <div className="flex">
                       {card.languages?.map((el: any, idx: any) => {
                         return (
                           <div
                             key={idx}
-                            className={`flex justify-center bg-${el} items-center px-1 py-0.5 ml-1 mt-1 border font-SCDream5 text-white rounded-xl desktop:text-xs tablet:text-[10px] text-[6px]`}
+                            className={`flex justify-center bg-${el} items-center px-1 py-0.5 ml-1 mt-1 font-SCDream5 text-white rounded-xl desktop:text-xs tablet:text-[10px] text-[6px]`}
                           >
                             {el}
                           </div>
@@ -155,9 +156,9 @@ const Card = () => {
                     </div>
                   </div>
                 </div>
-              </Link>
+              </div>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
       <>

--- a/client/components/Mypage/MypageInfo.tsx
+++ b/client/components/Mypage/MypageInfo.tsx
@@ -69,7 +69,7 @@ const MypageInfo = () => {
             alt="profile Image"
             width={200}
             height={200}
-            className="w-full h-full object-cover rounded-xl border border-borderColor"
+            className="w-full h-full object-cover rounded-xl"
           />
         </div>
         <div className="w-4/5 h-full flex flex-col justify-start items-start py-5">

--- a/client/components/detailComp/DetailBasicInfo.tsx
+++ b/client/components/detailComp/DetailBasicInfo.tsx
@@ -18,13 +18,13 @@ const DetailBasicInfo = (basicInfo: any) => {
     <>
       <div className="w-full h-full flex flex-row justify-center items-center">
         {/* profile Image */}
-        <div className="w-1/5 min-w-[200px] h-full flex flex-col justify-center items-center p-5">
+        <div className="w-1/5 min-w-[210px] h-full flex flex-col justify-center items-center p-4">
           <Image
             src={basicInfo.basicInfo?.profileImage}
             alt="profile Image"
-            width={200}
-            height={200}
-            className="rounded-xl border w-[150px] h-[150px] object-cover border-borderColor"
+            width={300}
+            height={300}
+            className="rounded-xl border w-[210px] h-[180px] object-cover border-borderColor"
           />
         </div>
         {/* lesson Info */}

--- a/client/components/detailComp/DetailExtra.tsx
+++ b/client/components/detailComp/DetailExtra.tsx
@@ -57,10 +57,7 @@ const DetailExtra = ({ extraData, lessonId, editable }: Props) => {
         introduction: extraData.data.introduction,
         detailCompany: extraData.data.detailCompany,
         personality: extraData.data.personality,
-        detailCost:
-          parseInt(extraData.data.detailCost.split("원")).toLocaleString(
-            "ko-KR",
-          ) + "원/회",
+        detailCost: extraData.data.detailCost,
         detailLocation: extraData.data.detailLocation,
       };
       setTextData(prompt);

--- a/client/components/detailComp/DetailExtra.tsx
+++ b/client/components/detailComp/DetailExtra.tsx
@@ -113,10 +113,10 @@ const DetailExtra = ({ extraData, lessonId, editable }: Props) => {
               <div className="font-SCDream5">{detailTitles[title]}</div>
               <div className="font-SCDream3">
                 {title === "careerImage" ? (
-                  <div className="border border-borderColor w-72 h-[100px] flex">
+                  <div className="w-80 h-28 tablet:w-[450px] tablet:h-36 desktop:w-[500px] desktop:h-40 flex">
                     {images?.map((image: any, idx: number) => (
                       <img
-                        className="w-1/3 p-1 rounded-xl aspect-square cursor-pointer"
+                        className="w-1/3 mr-5 rounded-xl aspect-square cursor-pointer"
                         key={image.careerImageId}
                         id={String(idx)}
                         src={image.filePath}

--- a/client/components/detailComp/DetailImageModal.tsx
+++ b/client/components/detailComp/DetailImageModal.tsx
@@ -1,4 +1,3 @@
-import CreateModalContainer from "components/reuse/container/CreateModalContainer";
 import ModalBackDrop from "components/reuse/container/ModalBackDrop";
 import Image from "next/image";
 
@@ -10,11 +9,9 @@ interface Props {
 const DetailImageModal = ({ modalImageClose, imagesToShow }: Props) => {
   return (
     <ModalBackDrop onClick={modalImageClose}>
-      {/* <CreateModalContainer> */}
       <div className="w-fit h-fit">
-        <Image src={imagesToShow} alt="imagesPop" width={300} height={300} />
+        <Image src={imagesToShow} alt="imagesPop" width={500} height={500} />
       </div>
-      {/* </CreateModalContainer> */}
     </ModalBackDrop>
   );
 };

--- a/client/hooks/auth/useDeleteLogout.tsx
+++ b/client/hooks/auth/useDeleteLogout.tsx
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/router";
+import { toast } from "react-toastify";
+import deleteLogout from "apis/auth/deleteLogout";
+import { useSetRecoilState } from "recoil";
+import { logUser } from "atoms/auth/authAtom";
+
+const useDeleteLogout = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const setLog = useSetRecoilState(logUser);
+  return useMutation(deleteLogout, {
+    onSuccess: res => {
+      queryClient.invalidateQueries(["cards"]);
+      toast.success("로그아웃 되었습니다.", {
+        autoClose: 2000,
+        position: toast.POSITION.TOP_RIGHT,
+      });
+      localStorage.clear();
+      setLog(prev => !prev);
+      router.push("/");
+    },
+    onError: res => {
+      console.log("logout failed");
+    },
+  });
+};
+
+export default useDeleteLogout;


### PR DESCRIPTION
#567 

[돈 단위/원화]
- [x] (02.09)아이콘 대신 원화 폰트 사용, 컬러 및 화면 표시내역 통일

[매인페이지]
- [x] (02.11) 카드 글자 배경 흰색으로 변경 및 이미지 클릭 시에도 상세페이지 이동 onClick

[상세페이지]
- [x] (02.11) 추가정보의 수업료 문자열 데이터로 `toLocalString` 삭제  
- [x] (02.11) 참고사진 border 삭제 및 참고사진과 popup 사진 upsize 

[마이페이지]
- [x] (02.11)프로필 이미지 border 삭제

[로그아웃]
- [x] (02.11) 로그아웃 통신으로 토큰 삭제 완료(현재 refresh가 필수라서 랜덤 문자열 넣어서 통신중)
