### PR TITLE
fix: 채팅서비스 맥북환경에서 메시지 2중전송 이슈 수정

### DIFF
--- a/client/components/chat/ChatComp.tsx
+++ b/client/components/chat/ChatComp.tsx
@@ -1,6 +1,6 @@
 import BackIcon from "assets/icon/BackIcon";
 import { useRecoilState } from "recoil";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { chatActive } from "atoms/chat/chatAtom";
 import ChatContent from "./ChatContent";
 import {
@@ -13,10 +13,10 @@ import {
 import { sendMsg, subscribeRoom, unSubscribeRoom } from "hooks/chat/socket";
 import useWindowSize from "hooks/useWindowSize";
 import useGetChatList from "hooks/chat/useGetChatList";
+import { useForm } from "react-hook-form";
 
 const ChatComp = () => {
   const [active, setActive] = useRecoilState(chatActive);
-  const [inputValue, setInputValue] = useState<string>("");
   const [chatList, setChatList] = useRecoilState(chatListState);
   const [roomIdNum, setRoomId] = useRecoilState(roomIdState);
   const [chatRoomName, setChatRoomName] = useRecoilState(chatDisplayName);
@@ -27,6 +27,8 @@ const ChatComp = () => {
   const { refetch: chatListFetch } = useGetChatList(roomIdNum);
 
   let windowSize = useWindowSize();
+
+  const { handleSubmit, register, setValue } = useForm();
 
   const handleSocketData = (data: any) => {
     setNewData(data);
@@ -39,22 +41,10 @@ const ChatComp = () => {
     setReceiverId(0);
   };
 
-  const handleInputChange = (e: any) => {
-    setInputValue(e.target.value);
-  };
-
-  const handlePressEnter = (e: any) => {
-    if (e.key === "Enter" && inputValue) {
-      sendMsg(roomIdNum, inputValue, receiverId);
-      setInputValue("");
-    }
-  };
-
-  const handleClickSubmit = (e: any) => {
-    if (inputValue) {
-      sendMsg(roomIdNum, inputValue, receiverId);
-      setInputValue("");
-    }
+  const onSubmit = (data: any) => {
+    let inputValue = data.value;
+    sendMsg(roomIdNum, inputValue, receiverId);
+    setValue("value", "");
   };
 
   useEffect(() => {
@@ -91,23 +81,21 @@ const ChatComp = () => {
         </div>
         {/* content */}
         <ChatContent chatList={chatList} />
-        {/* input */}
-        <div className="flex flex-row justify-center items-center w-[95%] h-[10%] border-t border-borderColor/30 ">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex flex-row justify-center items-center w-[95%] h-[10%] border-t border-borderColor/30 "
+        >
           <input
             type="text"
-            value={inputValue}
-            onChange={handleInputChange}
-            onKeyDown={handlePressEnter}
+            autoComplete="off"
             placeholder="메세지를 입력하세요"
             className="w-full h-full rounded-xl outline-none bg-bgColor font-SCDream3 text-textColor text-sm p-3"
+            {...register("value", { required: "true" })}
           />
-          <button
-            className="w-16 h-fit p-2 bg-pointColor rounded-md font-SCDream3 text-xs text-white flex flex-col justify-center items-center"
-            onClick={handleClickSubmit}
-          >
+          <button className="w-16 h-fit p-2 bg-pointColor rounded-md font-SCDream3 text-xs text-white flex flex-col justify-center items-center">
             전송
           </button>
-        </div>
+        </form>
       </div>
     </>
   );

--- a/client/components/chat/DesktopChatComp.tsx
+++ b/client/components/chat/DesktopChatComp.tsx
@@ -7,7 +7,6 @@ import { chatActive } from "atoms/chat/chatAtom";
 
 const DesktopChatComp = () => {
   const [active, setActive] = useRecoilState(chatActive);
-  console.log(active);
   return (
     <>
       <div className="w-full h-full flex flex-row justify-center items-start">

--- a/client/hooks/chat/useGetChatList.tsx
+++ b/client/hooks/chat/useGetChatList.tsx
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import getChatList from "apis/chat/getChatList";
 import { useRecoilState } from "recoil";
-import { chatListState, roomIdState, chatActive } from "atoms/chat/chatAtom";
+import { chatListState, chatActive } from "atoms/chat/chatAtom";
 
 const useGetChatList = (roomId: number) => {
   const [chatList, setChatList] = useRecoilState(chatListState);
-  // const [roomNumber, setRoomNumber] = useRecoilState(roomIdState);
   const [active, setActive] = useRecoilState(chatActive);
 
   return useQuery(["get/chatList"], () => getChatList(roomId), {

--- a/client/hooks/chat/useGetCreateRoom.tsx
+++ b/client/hooks/chat/useGetCreateRoom.tsx
@@ -8,7 +8,6 @@ const useGetCreateRoom = (lessonId: number) => {
   return useQuery(["get/createRoom"], () => getCreateRoom(lessonId), {
     enabled: false,
     onSuccess: res => {
-      console.log("success!!", res);
       router.push(`/chat/${lessonId}`);
     },
     onError: err => {

--- a/client/hooks/chat/usePostSendChat.tsx
+++ b/client/hooks/chat/usePostSendChat.tsx
@@ -2,14 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import postSendChat from "apis/chat/postSendChat";
 
 const usePostSendChat = () => {
-  return useMutation(postSendChat, {
-    onSuccess: res => {
-      console.log(res);
-    },
-    onError: err => {
-      console.log(err);
-    },
-  });
+  return useMutation(postSendChat);
 };
 
 export default usePostSendChat;


### PR DESCRIPTION
### 구현사항
- chatComp에서 input에 대한 submit로직을 기존 onkeydown이나 onchange가 아닌, react-hook-form을 통해 enter 또는 버튼 클릭에 대한 로직 간소화
- 불필요한 console.log 제거